### PR TITLE
config: Set github_repo to link the source

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,7 @@ params:
     #pygmentsCodefences: true
     #pygmentsCodefencesGuessSyntax: true
     #pygmentsStyle: "dracula"
+  github_repo: "https://github.com/openshift/ci-docs"
 menu:
   main:
   - name: Step Registry


### PR DESCRIPTION
Based on [these docs][1].

[1]: https://github.com/google/docsy/blob/4808e0ac5bb2df27021401fd33b2ef2756f751c2/userguide/content/en/docs/Adding%20content/repository-links.md#github_repo