### PR TITLE
content/en/docs/architecture/ci-operator: Fix '.ci-operator.yaml' quoting

### DIFF
--- a/content/en/docs/architecture/ci-operator.md
+++ b/content/en/docs/architecture/ci-operator.md
@@ -97,7 +97,7 @@ build_root:
   from_repository: true
 {{< / highlight >}}
 
-Afterwards, create a file named .`ci-operator`.yaml in your repository that contains the imagestream you want to use for
+Afterwards, create a file named `.ci-operator.yaml` in your repository that contains the imagestream you want to use for
 your `build_root`:
 
 {{< highlight yaml >}}


### PR DESCRIPTION
Typo from a93b6be28c (#4).

/assign @alvaroaleman