### PR TITLE
[DPTP-1699] update the Injecting Custom Credentials documentation

### DIFF
--- a/content/en/docs/architecture/step-registry.md
+++ b/content/en/docs/architecture/step-registry.md
@@ -171,8 +171,9 @@ ref:
   The step runs with custom credentials injected.
 {{< / highlight >}}
 
-Note that access to read these secrets from the namespace configured must be granted separately from the configuration being added to a step.
-By default, only secrets in the `test-credentials` namespace will be available for mounting into test steps.
+**Note that access to read these secrets from the namespace configured must be granted separately from the configuration being added to a step.
+By default, only secrets in the `test-credentials` namespace will be available for mounting into test steps. Please follow the secret-mirroring
+[documentation](https://github.com/openshift/release/blob/master/core-services/secret-mirroring/README.md) to set up a custom secret in that namespace**
 
 #### Injecting the `oc` CLI
 


### PR DESCRIPTION
In order for the users to be able to inject their custom credentials in their job, they need first to have their secret mapped in the test-crendentials namespace. 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>