### PR TITLE
nginx: use relative redirects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,4 @@ RUN set -x && ln -s /bin/bash /usr/bin/bash && make generate
 FROM nginxinc/nginx-unprivileged:1.18-alpine
 
 COPY --from=builder /src/public/ /usr/share/nginx/html/
+COPY nginx/relative_redirect.sh /docker-entrypoint.d/

--- a/nginx/relative_redirect.sh
+++ b/nginx/relative_redirect.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+sed -i \
+    '/server_name\s\+localhost;/a\    absolute_redirect off;' \
+    /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
Before:

```
$ curl --silent --show-error --head https://docs.ci.openshift.org/docs \
>     | grep --ignore-case location:
location: http://docs.ci.openshift.org:8080/docs/
```

After:

```
$ curl --silent --show-error --head localhost:8000/docs \
>     | grep --ignore-case location:
Location: /docs/
```