### PR TITLE
all: add description field for OpenGraph tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository holds the content of the Openshift CI documentation at https://d
 
 ## Development
 
-1. Clone the repository including submodules: `git clone --recursive git@github.com:openshift/ci-docs.git`
-1. Install the extended version of hugo as described here: https://gohugo.io/getting-started/installing/
+1. Clone the repository including submodules: `git clone --recursive git@github.com:openshift/ci-docs.git`. NOTE: Git submodules must be fully cloned for the server to work. If you've already cloned the repository without submodules, run `git submodule update --init --recursive --depth 1`. 
+1. Install the extended version of hugo as described [here](https://gohugo.io/getting-started/installing/). Generally, installing the extended binary from their [releases](https://github.com/gohugoio/hugo/releases) page is the best option. 
 1. Start the hugo server via `hugo server`
 1. Edit content and watch your changes live at http://localhost:1313/

--- a/content/en/docs/architecture/branch-protection.md
+++ b/content/en/docs/architecture/branch-protection.md
@@ -2,6 +2,7 @@
 title: "Branch Protection"
 date: 2020-10-05T11:14:39-04:00
 draft: false
+description: An overview of the integration between OpenShift CI and GitHub branch protection.
 ---
 ## What Is Branch Protection?
 

--- a/content/en/docs/architecture/ci-operator.md
+++ b/content/en/docs/architecture/ci-operator.md
@@ -2,6 +2,7 @@
 title: "CI Operator"
 date: 2020-10-05T11:14:39-04:00
 draft: false
+description: An overview of the architecture of ci-operator, the OpenShift CI workflow engine.
 ---
 
 # What is `ci-operator` and how does it work?

--- a/content/en/docs/architecture/private-repositories.md
+++ b/content/en/docs/architecture/private-repositories.md
@@ -1,7 +1,8 @@
 ---
-title: "Private repositories"
+title: "Private Repositories and Fixing Embargoed CVEs"
 date: 2020-10-05T11:14:39-04:00
 draft: false
+description: An overview of the workflows surrounding embargoed CVEs and private repository forks.
 ---
 
 OpenShift CI supports setting up CI jobs for private repositories mainly to allow temporary non-public development on

--- a/content/en/docs/architecture/quota-and-leases.md
+++ b/content/en/docs/architecture/quota-and-leases.md
@@ -1,7 +1,8 @@
 ---
-title: "Cloud quota handling and leases"
+title: "Cloud Quota Handling and Leases"
 date: 2020-10-05T11:14:39-04:00
 draft: false
+description: An overview of cloud compute quotas and aggregate concurrency limits for CI jobs.
 ---
 
 # How are Cloud Quota and Aggregate Concurrency Limits Handled?

--- a/content/en/docs/architecture/release-gating.md
+++ b/content/en/docs/architecture/release-gating.md
@@ -2,6 +2,7 @@
 title: "Extending OpenShift Release Gates"
 date: 2020-10-28T11:14:39-04:00
 draft: false
+description: An overview of how CI jobs are configured to gate OpenShift releases and how these configurations can be changed.
 ---
 
 ### Overview

--- a/content/en/docs/architecture/step-registry.md
+++ b/content/en/docs/architecture/step-registry.md
@@ -1,7 +1,8 @@
 ---
-title: "What are Multistage Tests and the Test Step Registry?"
+title: "Multi-Stage Tests and the Test Step Registry"
 date: 2020-10-05T10:49:33-04:00
 draft: false
+description: An overview of how multi-stage tests and the step registry make complex, DRY CI job definitions possible.
 ---
 
 The multistage test style in the `ci-operator` is a modular test design that allows users to create new tests by combining smaller, individual test steps.

--- a/content/en/docs/architecture/timeouts.md
+++ b/content/en/docs/architecture/timeouts.md
@@ -2,6 +2,7 @@
 title: "Job Execution Timeouts"
 date: 2020-12-21T23:27:39-04:00
 draft: false
+description: An overview of job execution timeouts, how to configure them and what the test workload is expected to do. 
 ---
 
 A typical OpenShift CI job runs [ci-operator](/docs/architecture/ci-operator/) in a pod which for each [step](/docs/architecture/step-registry/#step) of the job creates a pod, executing the commands defined by `tests.steps.test.commands` of a step in the job. A _test process_ is a process which runs such commands. There are timeouts in various phases of a job execution. In this document, we will explain those timeouts, show the logs if they occur in a job, and how the test process will be notified, and how to modify the values of those timeouts.

--- a/content/en/docs/getting-started/examples.md
+++ b/content/en/docs/getting-started/examples.md
@@ -2,6 +2,7 @@
 title: "Examples"
 date: 2020-10-05T11:14:39-04:00
 draft: false
+description: Examples of common tasks in CI configuration.
 ---
 
 # How do I add a job that runs the OpenShift end-to-end conformance suite on AWS?

--- a/content/en/docs/getting-started/useful-links.md
+++ b/content/en/docs/getting-started/useful-links.md
@@ -1,7 +1,8 @@
 ---
-title: "Useful links"
+title: "Useful Links"
 date: 2020-10-05T11:14:39-04:00
 draft: false
+description: Useful links to build farm clusters, hosted services, CI APIs and human contacts.
 ---
 
 # Clusters

--- a/content/en/docs/how-tos/add-jobs-to-testgrid.md
+++ b/content/en/docs/how-tos/add-jobs-to-testgrid.md
@@ -1,7 +1,8 @@
 ---
-title: "Add a job to TestGrid"
+title: "Add a Job to TestGrid"
 date: 2020-10-28T11:14:39-04:00
 draft: false
+description: How to add a new job to a TestGrid page and how this designation relates to release gating configuration.
 ---
 This document lays out the process of getting a CI job recorded as blocking or informing a release as well as the process for having job outputs exposed in a TestGrid page. While all jobs that block or inform a release are necessarily exposed in TestGrid pages, it is not required that a job have influence on an OpenShift release for the job's output to be present in a TestGrid overview.
 To just understand how a job is added to TestGrid skip to [How do I add a job to TestGrid?](#how-do-i-add-a-job-to-testgrid)

--- a/content/en/docs/how-tos/adding-a-new-secret-to-ci.md
+++ b/content/en/docs/how-tos/adding-a-new-secret-to-ci.md
@@ -2,6 +2,7 @@
 title: "Adding a New Secret to CI"
 date: 2020-12-21T10:08:01-04:00
 draft: false
+description: How to self-service manage secret data provided to jobs during execution.
 ---
 
 Jobs execute as `Pod`s; those that need access to sensitive information will have access to it through mounted Kubernetes

--- a/content/en/docs/how-tos/adding-changing-step-registry-content.md
+++ b/content/en/docs/how-tos/adding-changing-step-registry-content.md
@@ -2,6 +2,7 @@
 title: "Adding and Changing Step Registry Content"
 date: 2020-10-05T11:14:39-04:00
 draft: false
+description: How to contribute or change the content of the step registry.
 ---
 
 # Adding Content

--- a/content/en/docs/how-tos/contributing-openshift-release.md
+++ b/content/en/docs/how-tos/contributing-openshift-release.md
@@ -2,6 +2,7 @@
 title: "Contributing CI Configuration to the openshift/release Repository"
 date: 2020-10-05T11:14:39-04:00
 draft: false
+description: How to self-service contribute or change configuration for jobs or the broader CI system. 
 ---
 
 The [openshift/release](https://github.com/openshift/release) repository holds CI configuration for OpenShift component

--- a/content/en/docs/how-tos/external-images.md
+++ b/content/en/docs/how-tos/external-images.md
@@ -2,6 +2,7 @@
 title: "Using External Images in CI"
 date: 2020-10-05T11:14:39-04:00
 draft: false
+description: How to import external images to the CI environments for use in jobs.
 ---
 
 The `ci-operator` config only allows to reference `ImageStreamTags`, it does not allow to specify arbitrary Docker pull specs. In order

--- a/content/en/docs/how-tos/migrating-template-jobs-to-multistage.md
+++ b/content/en/docs/how-tos/migrating-template-jobs-to-multistage.md
@@ -2,6 +2,7 @@
 title: "Migrating CI Jobs from Templates to Multi-stage Tests"
 date: 2020-10-30T21:49:06+02:00
 draft: false
+description: How to self-service migrate jobs from using the deprecated Template approach to the multi-stage system.
 ---
 
 OpenShift CI offers two mechanisms for setting up end-to-end tests: older

--- a/content/en/docs/how-tos/mirroring-to-quay.md
+++ b/content/en/docs/how-tos/mirroring-to-quay.md
@@ -1,9 +1,9 @@
 ---
-title: "Mirror an image to an external registry"
+title: "Mirror an Image to an External Registry"
 date: 2020-10-05T11:14:39-04:00
 draft: false
+description: How to mirror an image built in the CI system out to an external registry.
 ---
-
 
 ## Requirements
 

--- a/content/en/docs/how-tos/notification.md
+++ b/content/en/docs/how-tos/notification.md
@@ -1,7 +1,8 @@
 ---
-title: "Setup Slack Alerts for Periodic Job Results"
+title: "Set Up Slack Alerts for Periodic Job Results"
 date: 2020-01-06T10:08:01-04:00
 draft: false
+description: How to set up alerting to Slack for a CI job.
 ---
 
 We can set up Slack alerts for job results by defining `reporter_config` in the job definition.

--- a/content/en/docs/how-tos/onboarding-a-new-component.md
+++ b/content/en/docs/how-tos/onboarding-a-new-component.md
@@ -2,6 +2,7 @@
 title: Onboarding a New Component for Testing and Merge Automation
 date: 2020-10-05T11:14:39-04:00
 draft: false
+description: How to onboard a new component repository to the CI system for testing and merge automation.
 ---
 
 ## Overview

--- a/content/en/docs/how-tos/testing-operator-sdk-operators.md
+++ b/content/en/docs/how-tos/testing-operator-sdk-operators.md
@@ -2,6 +2,7 @@
 title: "Testing Operators Built With The Operator SDK and Deployed Through OLM"
 date: 2020-10-05T11:14:39-04:00
 draft: false
+decription: How to configure tests for a component that is deployed as an operator through OLM.
 ---
 
 `ci-operator` supports building, deploying, and testing operator bundles, whether the operator repository uses the

--- a/content/en/docs/how-tos/use-registries-in-build-farm.md
+++ b/content/en/docs/how-tos/use-registries-in-build-farm.md
@@ -2,6 +2,7 @@
 title: "Interacting With CI Image Registries"
 date: 2020-12-15T16:08:01-04:00
 draft: false
+description: How to interact with the CI image registries, set up service account access and interact with images for a specific job.
 ---
 
 # Summary of Available Registries


### PR DESCRIPTION
We currently get the default behavior which is to embed the entire first
paragraph into the OpenGraph tag, which leads to Slack previews showing
massive walls of text when unfurling a link.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman @petr-muller