### PR TITLE
Fix a workflow name

### DIFF
--- a/content/en/docs/how-tos/migrating-template-jobs-to-multistage.md
+++ b/content/en/docs/how-tos/migrating-template-jobs-to-multistage.md
@@ -141,7 +141,7 @@ tests:
 ```
 
 There are multiple different workflows that implement the upgrade test:
-- [`openshift-upgrade-$PLATFORM-loki`](https://steps.ci.openshift.org/workflow/openshift-upgrade-aws): upgrade test workflow with logs collected via Loki (**recommended**)
+- [`openshift-upgrade-$PLATFORM`](https://steps.ci.openshift.org/workflow/openshift-upgrade-aws): upgrade test workflow with logs collected via Loki (**recommended**)
 - [`openshift-upgrade-$PLATFORM-hosted-loki`](https://steps.ci.openshift.org/workflow/openshift-upgrade-aws-hosted-loki): upgrade test workflow with logs collected via Loki hosted on Observatorium.
 
 ### `openshift_installer_src`


### PR DESCRIPTION
The link is fixed https://github.com/openshift/ci-docs/pull/81/files#diff-26dee95e4ddfaaf0560727186a3503f453730feecb75ebe90f4e06729aab2445R144

The reason the link was broken is that the loki version becomes the default and the loki is removed in the name of the workflow.
https://github.com/openshift/release/pull/14217

We correct the name here.

/cc @alvaroaleman 