### PR TITLE
Remove hostname in the base url

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-baseURL: "https://docs.ci.openshift.org/"
+baseURL: "/"
 languageCode: "en-us"
 title: "Openshift CI docs"
 theme: "docsy"


### PR DESCRIPTION
Asked https://discourse.gohugo.io/t/how-to-use-relative-urls/31052

It seems that the problem is caused by the theme.

But their example website has no such issues.
https://example.docsy.dev/docs/getting-started/example-page/
Its config is
https://github.com/google/docsy-example/blob/f96057c72dbc519c24b9d232a71109869200a047/config.toml#L1

Rehearsed with
https://github.com/openshift/ci-docs/pull/83
It works.

/cc @alvaroaleman @stevekuznetsov 