### PR TITLE
various: add view role to admins

### DIFF
--- a/content/en/docs/how-tos/adding-a-new-secret-to-ci.md
+++ b/content/en/docs/how-tos/adding-a-new-secret-to-ci.md
@@ -49,6 +49,22 @@ users:
   - jim
   - emily
 ---
+# this adds the admins to the project.
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: my-project-viewer-binding
+  namespace: my-project
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: view
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: my-project-admins
+    namespace: my-project
+---
 # this grants the right to view and update the Secret
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/content/en/docs/how-tos/use-registries-in-build-farm.md
+++ b/content/en/docs/how-tos/use-registries-in-build-farm.md
@@ -114,6 +114,22 @@ users:
   - jim
   - emily
 ---
+# this adds the admins to the project.
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: my-project-viewer-binding
+  namespace: my-project
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: view
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: my-project-admins
+    namespace: my-project
+---
 # this grants the right to read the ServiceAccount's credentials and pull
 # images to the admins.
 kind: RoleBinding


### PR DESCRIPTION
OpenShift will not be happy with users that try to look for their own
projects/namespaces or use `oc project` if they do not have at least
this permission in those namespaces. While the previous roles are
technically the minimal set, this additional role does not give them any
privileges that are worrisome and will allow the CLI to operate clearly.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman 
/cc @ray-harris 