### PR TITLE
Remove code block brackets inside of reusable test step example

### DIFF
--- a/content/en/docs/getting-started/examples.md
+++ b/content/en/docs/getting-started/examples.md
@@ -113,7 +113,7 @@ repository under `ci-operator/config/org/other/org-other-master.yaml`:
 {{< highlight yaml >}}
 - as: org-repo-e2e
   steps:
-    `cluster_profile`: aws
+    cluster_profile: aws
     workflow: ipi
     test:
     - ref: org-repo-e2e


### PR DESCRIPTION
Remove the code block brackets from the `cluster_profile` inside of the
"Adding a Reusable Test Step" example documentation.