### PR TITLE
ci-operator: always use secret wrapper

### DIFF
--- a/content/en/docs/architecture/step-registry.md
+++ b/content/en/docs/architecture/step-registry.md
@@ -130,13 +130,6 @@ Steps are more commonly expected to communicate between each other by using stat
 installs some components or changes configuration, a later step could check for that as a pre-condition by using `oc` or the API to view the
 cluster's configuration.
 
-The mechanism that makes this data sharing possible incurs a non-trivial
-overhead, directly reflected in the execution time of the test.  Simple steps
-that only require a read-only, private view of the shared directory that is not
-modified can be configured with the `readonly_shared_dir` field set to `true`.
-Doing so will likely result in tests with a significantly shorter and more
-consistent execution time.
-
 #### A Note on `$KUBECONFIG`
 
 In the default execution environment, commands run in steps will be given the `$KUBECONFIG` environment variable to allow them to interact with


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Follows up on https://github.com/openshift/ci-tools/pull/1718
 Part of [DPTP-1668](https://issues.redhat.com/browse/DPTP-1668)