### PR TITLE
Remove references to api.ci registry

### DIFF
--- a/content/en/docs/architecture/ci-operator.md
+++ b/content/en/docs/architecture/ci-operator.md
@@ -145,7 +145,7 @@ artifacts into a separate output image base. For instance, a repository could ad
 
 {{< highlight yaml >}}
 # this image is replaced by the build system to provide repository source code
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13 AS builder
+FROM registry.ci.openshift.org/ocp/builder:golang-1.13 AS builder
 # the repository's source code will be available under $GOPATH of /go
 WORKDIR /go/src/github.com/myorg/myrepo
 # this COPY bring the repository's source code from the build context into an image layer
@@ -154,7 +154,7 @@ COPY . .
 RUN go build ./cmd/...
 
 # this is the production output image base and matches the "base" build_root
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.5:base
+FROM registry.ci.openshift.org/openshift/origin-v4.5:base
 # inject the built artifact into the output
 COPY --from=builder /go/src/github.com/myorg/myrepo/mybinary /usr/bin/
 {{< / highlight >}}
@@ -176,7 +176,7 @@ images:
   inputs:
     bin: # declares that the "bin" tag is used as the builder image when overwriting that FROM instruction
       as:
-      - "registry.svc.ci.openshift.org/ocp/builder:golang-1.13"
+      - "registry.ci.openshift.org/ocp/builder:golang-1.13"
   to: "mycomponent" # names the output container image "mycomponent"
 - dockerfile_path: "tests/Dockerfile"
   from: "test-bin" # base the build off of the built test binaries

--- a/content/en/docs/how-tos/contributing-openshift-release.md
+++ b/content/en/docs/how-tos/contributing-openshift-release.md
@@ -1,6 +1,6 @@
 ---
 title: "Contributing CI Configuration to the openshift/release Repository"
-description: How to self-service contribute or change configuration for jobs or the broader CI system. 
+description: How to self-service contribute or change configuration for jobs or the broader CI system.
 ---
 
 The [openshift/release](https://github.com/openshift/release) repository holds CI configuration for OpenShift component
@@ -54,20 +54,20 @@ that runs all these tools before a pull request submission:
 {{< highlight make >}}
 $ make update
 make jobs
-docker pull registry.svc.ci.openshift.org/ci/ci-operator-prowgen:latest
-docker run --rm <...> registry.svc.ci.openshift.org/ci/ci-operator-prowgen:latest <...>
-docker pull registry.svc.ci.openshift.org/ci/sanitize-prow-jobs:latest
-docker run --rm <...> registry.svc.ci.openshift.org/ci/sanitize-prow-jobs:latest <...>
+docker pull registry.ci.openshift.org/ci/ci-operator-prowgen:latest
+docker run --rm <...> registry.ci.openshift.org/ci/ci-operator-prowgen:latest <...>
+docker pull registry.ci.openshift.org/ci/sanitize-prow-jobs:latest
+docker run --rm <...> registry.ci.openshift.org/ci/sanitize-prow-jobs:latest <...>
 make ci-operator-config
-docker pull registry.svc.ci.openshift.org/ci/determinize-ci-operator:latest
-docker run --rm -v <...> registry.svc.ci.openshift.org/ci/determinize-ci-operator:latest <...>
+docker pull registry.ci.openshift.org/ci/determinize-ci-operator:latest
+docker run --rm -v <...> registry.ci.openshift.org/ci/determinize-ci-operator:latest <...>
 make prow-config
-docker pull registry.svc.ci.openshift.org/ci/determinize-prow-config:latest
-docker run --rm <...> registry.svc.ci.openshift.org/ci/determinize-prow-config:latest <...>
+docker pull registry.ci.openshift.org/ci/determinize-prow-config:latest
+docker run --rm <...> registry.ci.openshift.org/ci/determinize-prow-config:latest <...>
 make registry-metadata
-docker pull registry.svc.ci.openshift.org/ci/generate-registry-metadata:latest
+docker pull registry.ci.openshift.org/ci/generate-registry-metadata:latest
 <...>
-docker run --rm -v <...> registry.svc.ci.openshift.org/ci/generate-registry-metadata:latest <...>
+docker run --rm -v <...> registry.ci.openshift.org/ci/generate-registry-metadata:latest <...>
 {{< / highlight >}}
 
 ### Rehearsals
@@ -162,9 +162,9 @@ through the necessary steps and generates the configuration for you:
 
 {{< highlight make >}}
 make new-repo
-docker pull registry.svc.ci.openshift.org/ci/repo-init:latest
+docker pull registry.ci.openshift.org/ci/repo-init:latest
 <...>
-docker run --rm -it <...> registry.svc.ci.openshift.org/ci/repo-init:latest --release-repo <...>
+docker run --rm -it <...> registry.ci.openshift.org/ci/repo-init:latest --release-repo <...>
 Welcome to the repository configuration initializer.
 In order to generate a new set of configurations, some information will be necessary.
 

--- a/content/en/docs/how-tos/use-registries-in-build-farm.md
+++ b/content/en/docs/how-tos/use-registries-in-build-farm.md
@@ -12,7 +12,6 @@ some comments on their purpose:
 |  Cluster  | Registry URL                                                                                                 | Note                                                                                                                                    |
 |-----------|--------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
 | [`app.ci`](https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/) | [registry.ci.openshift.org](https://registry.ci.openshift.org)                                                       | the authoritative, central CI registry                                                                                                  |
-| [`api.ci`](https://console.svc.ci.openshift.org/) | [registry.svc.ci.openshift.org](https://registry.svc.ci.openshift.org)                                               | the previous central registry; contains identical images to the authoritative registry                                                  |
 | [`build01`](https://console.build01.ci.openshift.org/) | [registry.build01.ci.openshift.org](https://registry.build01.ci.openshift.org)                                       | contains up-to-date image copies from the authoritative registry for jobs that run on this build farm only                              |
 | [`build02`](https://console.build02.ci.openshift.org/) | [registry.build02.ci.openshift.org](https://registry.build02.ci.openshift.org)                                       | contains up-to-date image copies from the authoritative registry for jobs that run on this build farm only                              |
 | `vsphere` | [registry.apps.build01-us-west-2.vmc.ci.openshift.org](https://registry.apps.build01-us-west-2.vmc.ci.openshift.org) | contains up-to-date image copies from the authoritative registry for jobs that run on this build farm only; only open to vsphere admins |
@@ -29,9 +28,7 @@ copies they hold are up-to-date and jobs that run there run with the correct con
 
 {{< alert title="Info" color="info" >}}
 Today, we are in the process of migrating between authoritative image registries. The current authoritative
-registry is [registry.ci.openshift.org](https://registry.ci.openshift.org). The previous authoritative registry,
-[registry.svc.ci.openshift.org](https://registry.svc.ci.openshift.org), contains an up-to-date version of all images as well,
-and will continue to do so for the time being while users migrate to using the new registry.
+registry is [registry.ci.openshift.org](https://registry.ci.openshift.org).
 {{< /alert >}}
 
 # Common Questions
@@ -150,7 +147,7 @@ subjects:
     namespace: my-project
 ```
 
-After the pull request is merged, your manifests will be automatically applied to the cluster hosting the central CI 
+After the pull request is merged, your manifests will be automatically applied to the cluster hosting the central CI
 registry. Make sure your `oc` CLI is [logged in](#how-do-i-log-in-to-pull-images-that-require-authentication) to the
 `app.ci` cluster via the [console](https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/), then you
 will be able to generate the pull credentials for your `ServiceAccount` using the `oc` CLI:


### PR DESCRIPTION
Makes the links job fail: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-docs/114/pull-ci-openshift-ci-docs-master-links/1374744159927144448