### PR TITLE
content/en/docs/how-tos/testing-operator-sdk-operators: "stable" -> "pipeline"

### DIFF
--- a/content/en/docs/how-tos/testing-operator-sdk-operators.md
+++ b/content/en/docs/how-tos/testing-operator-sdk-operators.md
@@ -57,7 +57,7 @@ operator:
   substitutions:
   # replace references to the operand with the imported version (`base_images` stanza)
   - pullspec: "quay.io/openshift/operand:1.3"
-    with: "stable:operand"
+    with: "pipeline:operand"
   # replace references to the operator with the built version (`images` stanza)
   - pullspec: "quay.io/openshift/tested-operator:1.3"
     with: "pipeline:tested-operator"


### PR DESCRIPTION
From a93b6be28c (#4), `pipeline` is for:

> Input images described with base_images and build_root as well as images holding built artifacts (such as src or bin) and output images as defined in images.

while `stable` is for:

> ..., but for the release:latest release payload. Appropriate tags are overridden using the container images built during the test.

In this example, `operand` is coming from `base_images`, and is not being built for this job, so we want to use `pipeline:operand` to get at it.