### PR TITLE
branching: master/main does not require cherry-pick-approved in feature freeze

### DIFF
--- a/content/en/docs/architecture/branching.md
+++ b/content/en/docs/architecture/branching.md
@@ -24,7 +24,7 @@ During feature freeze, the expectation is that merges to the active development 
 
 |*Branch*|*Promotes To*|*Merge Criteria*|*Fast-Forwarded?*|
 |-|-|-|-|
-|`master/main`|`ocp/4.x`|`lgtm`, `approved`, `bugzilla/valid-bug`, `cherry-pick-approved`|no|
+|`master/main`|`ocp/4.x`|`lgtm`, `approved`, `bugzilla/valid-bug`|no|
 |`release-4.x-n`|`ocp/4.x-n`|`lgtm`, `approved`, `bugzilla/valid-bug`, `cherry-pick-approved`|no|
 |`release-4.x`|nowhere|merges blocked|yes|
 |`release-4.x+1`|`ocp/4.x+1`|merges blocked|yes|


### PR DESCRIPTION
I think that @eparis 's [comment](https://github.com/openshift/ci-docs/pull/108#discussion_r589492228) was [interpreted](https://github.com/openshift/ci-docs/pull/108#issuecomment-792882984) incorrectly. We never needed approvals on `master`.

/cc @jupierce @stevekuznetsov