### PR TITLE
indicate where the ci registry is

### DIFF
--- a/content/en/docs/getting-started/useful-links.md
+++ b/content/en/docs/getting-started/useful-links.md
@@ -8,7 +8,7 @@ description: Useful links to build farm clusters, hosted services, CI APIs and h
 The clusters that currently comprise CI are:
 
 * [api.ci](https://console.svc.ci.openshift.org/): legacy Openshift 3.11 cluster in GCP. Job execution is being migrated out of it.
-* [app.ci](https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/): Openshift Dedicated 4.x cluster containing most Prow services.
+* [app.ci](https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/): Openshift Dedicated 4.x cluster containing most Prow services including registry.ci.openshift.org (our image registry for CI builds).
 * [build01](https://console.build01.ci.openshift.org/): Openshift 4.x cluster in AWS that executes a growing subset of the jobs.
 * [build02](https://console.build02.ci.openshift.org/): Openshift 4.x cluster in GCP that executes a growing subset of the jobs.
 * `vsphere`: external cluster used for vSphere tests, not managed by DPTP.


### PR DESCRIPTION
I've been trained to go here for links to CI stuff and I know that i'm looking to log into a console, copy the `oc login` command, and `oc registry login`.  I just didn't know which cluster to use.