### PR TITLE
content/en/docs/architecture/ci-operator: More details for release channel/version

### DIFF
--- a/content/en/docs/architecture/ci-operator.md
+++ b/content/en/docs/architecture/ci-operator.md
@@ -344,9 +344,9 @@ releases:
       product: okd
       version: "4.3"
   latest:
-    release:          # references a version released to customers
-      channel: stable # configures the release channel to search
-      version: "4.4"
+    release:          # references a version from Red Hat's Cincinnati update service https://api.openshift.com/api/upgrades_info/v1/graph
+      channel: stable # configures the release channel to search.  The major.minor from version will be appended automatically, so the Cincinnati request for this will use 'stable-4.4'.
+      version: "4.4"  # selects the largest Semantic Version in the configured channel.  https://semver.org/spec/v2.0.0.html#spec-item-11
   previous:
     candidate:
       product: ocp


### PR DESCRIPTION
Expanding on the descriptions from a93b6be28c (#4).  I didn't understand:

* Whether this was contacting [the official Red Hat Cincinnati](https://api.openshift.com/api/upgrades_info/v1/graph) or [the release-controller Cincinnati](https://amd64.ocp.releases.ci.openshift.org/graph).  It's the former.

* The fact that `channel` has the major.minor suffix added instead of being passed through directly to Cincinnati.

* The fact that the `version` is not (yet, openshift/ci-tools#1927) allowed to include a full semantic version.  Instead, it's currently only used to append to `channel`, and the selected version is the largest SemVer entry in that channel.

[1]: https://github.com/openshift/ci-tools/pull/1927