### PR TITLE
content/en/docs/architecture/ci-operator: Document explicit release version

### DIFF
--- a/content/en/docs/architecture/ci-operator.md
+++ b/content/en/docs/architecture/ci-operator.md
@@ -347,6 +347,10 @@ releases:
     release:          # references a version from Red Hat's Cincinnati update service https://api.openshift.com/api/upgrades_info/v1/graph
       channel: stable # configures the release channel to search.  The major.minor from version will be appended automatically, so the Cincinnati request for this will use 'stable-4.4'.
       version: "4.4"  # selects the largest Semantic Version in the configured channel.  https://semver.org/spec/v2.0.0.html#spec-item-11
+  firstz:
+    release:           # same as the 'latest' example above
+      channel: stable  # same as the 'latest' example above
+      version: "4.4.3" # selects the 4.4.3 release.  This is probably only useful for tip-to-first-z rollback tests.  Most folks will want to use the 'latest' example above
   previous:
     candidate:
       product: ocp


### PR DESCRIPTION
Catching up with openshift/ci-tools#1927.  We'd flubbed 4.4.2 and earlier, so 4.4.3 ended up being the name of the first GA 4.4 release:

```console
$ curl -sH accept:application/json 'https://api.openshift.com/api/upgrades_info/v1/graph?channel=stable-4.4' | jq -r '.nodes[] | .version + " " + .payload' | grep '^4[.]4[.]' | sort -V | head -n2
4.4.3 quay.io/openshift-release-dev/ocp-release@sha256:039a4ef7c128a049ccf916a1d68ce93e8f5494b44d5a75df60c85e9e7191dacc
4.4.4 quay.io/openshift-release-dev/ocp-release@sha256:baa687f29b0ac155d8f4c6914056d36d68f343feb9c1e82b46eef95819d00be5
```