### PR TITLE
content/en/docs/how-tos/add-jobs-to-testgrid: Mention 'broken' near _allow-list.yaml

### DIFF
--- a/content/en/docs/how-tos/add-jobs-to-testgrid.md
+++ b/content/en/docs/how-tos/add-jobs-to-testgrid.md
@@ -33,8 +33,7 @@ If the release gating job has an entry in the [`_allow-list.yaml`](https://githu
 {{< /alert >}}
 
 #### Adding a non-release gating job to TestGrid
-If a non-release gating job is added to the [`_allow-list.yaml`](https://github.com/openshift/release/blob/master/core-services/testgrid-config-generator/_allow-list.yaml) it would simply add the job to TestGrid in the specified dashboard.
-
+If a non-release gating job is added to the [`_allow-list.yaml`](https://github.com/openshift/release/blob/master/core-services/testgrid-config-generator/_allow-list.yaml) it would simply add the job to TestGrid in the specified dashboard (which is useful for marking jobs `broken`).
 
 Refer to the README for the [TestGrid config generator tool](https://github.com/openshift/ci-tools/tree/master/cmd/testgrid-config-generator) for more details regarding how the testgrid-config-generator works.
 


### PR DESCRIPTION
So folks searching for `broken` are more likely to be able to realize that's how you mark a job broken.