### PR TITLE
Fix the cluster-display's URL

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,7 @@ contentDir: "content/en"
 params:
   offlineSearch: true
   github_repo: "https://github.com/openshift/ci-docs"
-  api_v1_url: "http://localhost:8090"
+  api_v1_url: "https://cluster-display.ci.openshift.org"
 enableGitInfo: true
 menu:
   main:


### PR DESCRIPTION
/hold

we should verify if it works on the preview of this PR after https://github.com/openshift/release/pull/19507 is merged.

/cc @alvaroaleman 