### PR TITLE
Improve cluster pool creating document

### DIFF
--- a/content/en/docs/how-tos/cluster-claim.md
+++ b/content/en/docs/how-tos/cluster-claim.md
@@ -3,62 +3,232 @@ title: "Creating a Cluster Pool"
 description: How to create a cluster pool from which a job can claim a cluster.
 ---
 
-This document describes how to set up cluster pools backed by custom cloud platform accounts owned by users or teams that want their jobs to use clusters provisioned with these custom accounts.
+`ci-operator` [allows](https://docs.ci.openshift.org/docs/architecture/ci-operator/#testing-with-a-cluster-from-a-cluster-pool)
+CI jobs that need an OCP cluster for testing to claim a pre-installed one from so-called _"cluster pools"_
+using [Hive](https://github.com/openshift/hive). This document describes how to set up custom pools backed by custom
+cloud platform accounts owned by users or teams that want their jobs to use clusters provisioned with these custom
+accounts.
 
 ## Prerequisites
 
-* Verify that the cloud platform you want to use is supported by [Hive](https://github.com/openshift/hive#supported-cloud-providers) (the cluster pool mechanism back-end).
-* [Configure the cloud account](https://docs.openshift.com/container-platform/4.7/installing/installing-preparing.html): Hive does not require more configuration of the cloud account than installing an OpenShift cluster. Make sure that the account has quotas for the pools to contain the desired number of clusters.
+* Verify that the cloud platform you want to use is supported
+  by [Hive](https://github.com/openshift/hive#supported-cloud-providers)
+* [Configure the cloud account](https://docs.openshift.com/container-platform/4.7/installing/installing-preparing.html):
+  Hive does not require more configuration of the cloud account than installing an OpenShift cluster. Make sure that the
+  account has quotas for the pools to contain the desired number of clusters.
 
-## Create a cluster pool
+## Instructions
 
-A Hive instance is deployed on an dedicated OpenShift cluster, called `hive`. All the resources for a cluster pool are managed on the `hive` cluster.
-In the openshift/release repository, create a folder in the [`clusters/hive/pools`](https://github.com/openshift/release/tree/master/clusters/hive/pools) directory that will contain manifests of all your pools (see [openshift-ci](https://github.com/openshift/release/tree/master/clusters/hive/pools/openshift-ci) as an example). Then place the manifests for the new `ClusterPool` there.
+The OpenShift CI Hive instance is deployed on a dedicated OpenShift cluster, called `hive` and all resources involved in
+creating and running a custom cluster pool need to be created there. This is done via GitOps in the `openshift/release`
+repository.
+
+### Prepare Your Cloud Platform Credentials
+
+First, you need to make sure the cloud platform credentials that will be used to install cluster for the pool are
+available on the `hive` cluster. If you are not familiar with OpenShift CI custom secret management, please consult the
+[Adding a New Secret to CI](/docs/how-tos/adding-a-new-secret-to-ci/) document first.
+
+1. Select a suitable collection in [Vault](https://vault.ci.openshift.org/ui/) to hold your cluster pool secret.
+   Alternatively, create a new suitable collection
+   in [collection self-service](https://selfservice.vault.ci.openshift.org/).
+2. In the selected collection, create a secret with the necessary keys and values. The specific needed keys depend on
+   the cloud platform; consult the
+   Hive [Cloud Credentials](https://github.com/openshift/hive/blob/master/docs/using-hive.md#cloud-credentials)
+   document.
+3. Set `secretsync/target-clusters` key to `hive` to make sure your credentials are synced to the necessary cluster.
+4. Set `secretsync/target-namespace` key to a name of the namespace that will hold your pools (`$team-cluster-pool` is a
+   good baseline name).
+5. Set `secretsync/target-name` to a name under which the secret will be accessible in the
+   cluster (`$platform-credentials` is a good baseline name).
+
+At the end, you should have a secret similar to the following in Vault:
+
+#### selfservice/dptp-demo-collection/dptp-demo-pool-credentials:
+
+```json
+{
+  "aws_access_key_id": "AWS KEY ID",
+  "aws_secret_access_key": "AWS ACCESS KEY",
+  "secretsync/target-clusters": "hive",
+  "secretsync/target-name": "demo-aws-credentials",
+  "secretsync/target-namespace": "dptp-demo-cluster-pools"
+}
+```
+
+### Create a Directory for Your Manifests
+
+1. In the openshift/release repository, create a folder in
+   the [`clusters/hive/pools`](https://github.com/openshift/release/tree/master/clusters/hive/pools) directory that will
+   contain manifests of all your resources (
+   see [`openshift-ci`](https://github.com/openshift/release/tree/master/clusters/hive/pools/openshift-ci) as an
+   example).
+
+2. Create `OWNERS` file in the directory to allow your teammates make and approve changes.
+3. Create a manifest for the namespace that will hold your Hive resources (the namespace name must match the one where
+   you instructed [Vault to sync your secret](#prepare-your-cloud-platform-credentials)):
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dptp-demo-cluster-pools
+```
+
+### Create a Manifest for Your Cluster Pool
+
+Create a manifest for your cluster pool. The `ClusterPool` resource specification is available
+at [Hive's documentation](https://pkg.go.dev/github.com/openshift/hive/apis@master/hive/v1#ClusterPool); consult that
+document for more information about individual fields.
 
 ```yaml
 apiVersion: hive.openshift.io/v1
 kind: ClusterPool
 metadata:
-  name: ci-ocp-4-7-amd64-aws-us-east-1
-  namespace: cvp-cluster-pool
+  name: dptp-demo-cluster-pool # name is not relevant but of course must be unique
+  namespace: dptp-demo-cluster-pools
   labels: # architecture, cloud, owner, product, version are used to filter out a pool when a job claims a cluster
     architecture: amd64
     cloud: aws
     product: ocp
-    owner: cvp
-    region: us-east-1 # the region where the cluster is installed, not yet used in label matching
+    owner: dptp-demo
     version: "4.7"
 spec:
-  baseDomain: hive.example.org # the base domain to install the cluster
+  baseDomain: dptp-demo.openshift.org # the base domain to install the cluster
   imageSetRef:
     name: ocp-4.7.0-amd64 # the name of the imageSet which determines the image to install the cluster
   installConfigSecretTemplateRef:
-    name: install-config-aws-us-east-1 # the name of the secret with an installation config for the installer
+    name: dptp-demo-install-config # the name of the secret with an installation config for the installer
   skipMachinePools: true
   platform:
     aws:
       credentialsSecretRef:
-        name: hive-aws-credentials # the name of the secret with the credentials of the cloud account
+        name: demo-aws-credentials # the name of the secret with the credentials of the cloud account
       region: us-east-1
   pullSecretRef:
-    name: pull-secret # the name of the pull secret used by installer
+    name: pull-secret
   size: 1 # the number of clusters that Hive should keep provisioned and waiting for use.
-  maxSize: 10 # the maximum number of clusters that have not been destroyed.
+  maxSize: 10 # the maximum number of clusters that can exist at the same time.
 ```
 
-Hive maintains the number of clusters in the pool as specified by its `size`. A provisioned cluster will be [hibernating](https://github.com/openshift/hive/blob/master/docs/hibernating-clusters.md) after staying idled for sometime and can be waken up if a job claims it. Hive removes it from the pool once it is claimed and creates a new cluster to maintain the pool's `size`. The cluster will be destroyed after 4 hours since it is claimed. All clusters before destruction consume the quotas of the cloud account. If several jobs claim a cluster simultaneously, Hive will feed all of them up until the number of living clusters reaches the pool's `maxSize`. The meaning of other fields in the pool specification is available at [Hive's documentation](https://pkg.go.dev/github.com/openshift/hive/apis@master/hive/v1#ClusterPool).
+Pay attention to the following stanzas:
 
-It is suggested to put the relevant manifests to the cluster pool in the same `namespace`. Hive [replaces](https://github.com/openshift/hive/blob/master/docs/clusterpools.md#install-config-template) `baseDomain` with the value taken from the pool's spec and `metadata.name` with a random string in the installation config from `secret/install-config-aws-us-east-1` and then passes it onto the OpenShift installer. Customizations such as the number of workers and the type of instances can be made there. A `ClusterImageSet` which a cluster level CRD defines the production and its version of the installed cluster.
+1. `metadata.labels`: These labels will be used by jobs to specify what cluster they want to obtain for their testing.
+2. `spec.baseDomain`: A base domain for all clusters created in this pool. This is the domain for which you created a
+   hosted zone when configuring the cloud platform account (see [prerequisites](#prerequisites)).
+3. `spec.imageSetRef`: A reference to a `ClusterImageSet` in the cluster that determines the exact version of clusters
+   created in the pool. `ClusterImageSets` are cluster-scoped resources and their manifests are present
+   in [`clusters/hive/pools`](https://github.com/openshift/release/tree/master/clusters/hive/pools) directory. Either
+   select one of the already available, or create a new one. DPTP maintains a set of `ClusterImageSets` that are
+   regularly bumped to most recent released OCP versions.
+4. `spec.installConfigSecretTemplateRef`: a reference to a `Secret` that serves as an installation config template. See
+   the [below section](#create-a-manifest-for-your-install-config-template-secret) for more information.
+5. `spec.platform.$CLOUD.credentialsSecretRef`: A reference to the secret you created in
+   the [Prepare your cloud platform credentials](#prepare-your-cloud-platform-credentials) section.
+6. `pullSecretRef.name`: Must be kept `pull-secret`. OpenShift CI will populate your namespace with this secret that
+   contains all pull secrets necessary to install an OCP cluster.
 
-If any manifest contains sensitive information, e.g., `secret/hive-aws-credentials`, see [how to add a secret to CI](/docs/how-tos/adding-a-new-secret-to-ci/). Make sure to set the key `secretsync/target-clusters: "hive"` for the secret to ensure it is synced only to the cluster that needs it.
+#### Sizing Your Cluster Pool
 
-When those manifests for a pool are applied on the `hive` cluster, the cluster pool `cvp-cluster-pool` can be used to [claim a cluster for tests](/docs/architecture/ci-operator/#testing-with-a-cluster-from-a-cluster-pool).
+Hive maintains the number of clusters in the pool as specified by its `size`. A provisioned cluster will
+be [hibernating](https://github.com/openshift/hive/blob/master/docs/hibernating-clusters.md) after staying idled for
+some time and can be woken up if a job claims it. Hive removes it from the pool once it is claimed and creates a new
+cluster to maintain the pool's `size`. The cluster will be destroyed 4 hours after it is claimed. If several jobs file
+claims from one `ClusterPool` simultaneously, Hive will fulfill all claims until the number of living clusters reaches
+the pool's `maxSize`.
+
+All live and hibernated clusters consume resources in the cloud account, so your `maxSize` should be set according to
+your cloud platform limits and quotas and presence of other cluster pools or other resource consumption in your cloud
+platform account.
+
+### Create a Manifest for Your Install Config Template Secret
+
+This secret is used via a reference from the [`ClusterPool` resource](#create-a-manifest-for-your-cluster-pool) and
+allows customizing the cluster, such as setting the number of workers or the type of instances. It is usually not
+necessary to keep this manifest actually secret as it often does not contain anything sensitive.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dptp-demo-install-config
+  namespace: dptp-demo-cluster-pools
+stringData:
+  install-config.yaml: |
+    apiVersion: v1
+    compute:
+    - architecture: amd64
+      hyperthreading: Enabled
+      name: worker
+      platform: {}
+      replicas: 3
+    controlPlane:
+      architecture: amd64
+      hyperthreading: Enabled
+      name: master
+      platform: {}
+      replicas: 3
+    metadata:
+      name: test01
+    networking:
+      clusterNetwork:
+      - cidr: 10.128.0.0/14
+        hostPrefix: 23
+      machineNetwork:
+      - cidr: 10.0.0.0/16
+      networkType: OpenShiftSDN
+      serviceNetwork:
+      - 172.30.0.0/16
+    publish: External
+type: Opaque
+```
+
+### Submit a PR to openshift/release
+
+Submit a PR to openshift/release with all your new manifests. After the PR merges, the manifests are committed to the
+cluster and Hive starts installing clusters for your pool.
+
+### Use the Cluster Pool from a CI Job
+
+After the pool manifests are applied on the `hive` cluster, the cluster pool can by used by CI jobs by setting
+a `cluster_claim` stanza with values matching the labels on the pool:
+
+```yaml
+tests:
+- as: some-test
+  cluster_claim:
+    architecture: amd64
+    cloud: aws
+    owner: dptp-demo
+    product: ocp
+    timeout: 1h0m0s
+    version: "4.7"
+...
+```
+
+For more details about tests that run on claimed clusters, see
+the [testing with a cluster from a cluster pool](/docs/architecture/ci-operator/#testing-with-a-cluster-from-a-cluster-pool)
+document.
+
+## Troubleshooting Cluster Pools
+
+The cluster pools are maintained by Hive behind the scenes, so installation failures, cloud platform account
+misconfigurations and similar issues are not exposed to actual CI jobs: the jobs will simply never successfully claim a
+cluster if Hive fails to install them. Currently, cluster pool owners cannot access the logs or other troubleshooting
+information on the `hive` cluster. For now, work with DPTP (ping `@dptp-helpdesk` on #forum-testplatform Slack channel)
+to troubleshoot pools that never get ready clusters.
 
 ## Existing Cluster Pools
 
-The following table shows the existing cluster pools that a user can claim a cluster from. Each pool defines a set of characters about the clusters that are provisioned out of it. For instance, the cluster pool `ci-ocp-4-6-amd64-aws-us-east-1` is composed of OCP 4.6 clusters on AWS's `us-east-1` region. The values of **READY**, **SIZE** and **MAX SIZE** are taken from [the status and the specification of each pool](https://pkg.go.dev/github.com/openshift/hive/apis@master/hive/v1#ClusterPool).  Clicking <img src="https://datatables.net/examples/resources/details_open.png" alt="details button"> shows the more details of the cluster pool, such as the release image that is used for provisioning a cluster and the labels defined on the pool. The Search box can filter out the pools according to the given keyword.
+The following table shows the existing cluster pools that a user can claim a cluster from. Each pool defines a set of
+characters about the clusters that are provisioned out of it. For instance, the cluster
+pool `ci-ocp-4-6-amd64-aws-us-east-1` is composed of OCP 4.6 clusters on AWS's `us-east-1` region. The values of **
+READY**, **SIZE** and **MAX SIZE** are taken
+from [the status and the specification of each pool](https://pkg.go.dev/github.com/openshift/hive/apis@master/hive/v1#ClusterPool)
+. Clicking <img src="https://datatables.net/examples/resources/details_open.png" alt="details button"> shows the more
+details of the cluster pool, such as the release image that is used for provisioning a cluster and the labels defined on
+the pool. The Search box can filter out the pools according to the given keyword.
 
-</script>
 {{< rawhtml >}}
 
 <table id="table_pools" class="display" style="width:100%">
@@ -77,6 +247,7 @@ The following table shows the existing cluster pools that a user can claim a clu
 </table>
 {{< /rawhtml >}}
 
-{{< alert title="Info" color="info" >}}
-The cluster pools in namespace `fake-cluster-pool` are for DPTP's internal usage, such as e2e tests for the pool feature of `ci-operator`. For example, the claims against the pool `fake-ocp-4-7-amd64-aws` are annotated with `hive.openshift.io/fake-cluster: "true"` which tells Hive to return a syntactically correct `kubeconfig` right away without provisioning any cluster.
-{{< /alert >}}
+{{< alert title="Info" color="info" >}} The cluster pools in namespace `fake-cluster-pool` are for DPTP's internal
+usage, such as e2e tests for the pool feature of `ci-operator`. For example, the claims against the
+pool `fake-ocp-4-7-amd64-aws` are annotated with `hive.openshift.io/fake-cluster: "true"` which tells Hive to return a
+syntactically correct `kubeconfig` right away without provisioning any cluster. {{< /alert >}}


### PR DESCRIPTION
The previous document assumed too much knowledge about everything: Hive, OCP installer, OpenShift CI custom secret management... We gave the user links and let him connect the pieces together. I attempted to write a much more detailed doc a user can directly follow, with links being used only to provide necessary background if needed.

/cc @stevekuznetsov @hongkailiu 

/cc @jsztuka 
Please take a look if a doc like this would improve your experience with setting up the custom pool, thanks!