### PR TITLE
Fix docs for injecting user-owner secrets to cluster profiles

### DIFF
--- a/content/en/docs/how-tos/adding-a-cluster-profile.md
+++ b/content/en/docs/how-tos/adding-a-cluster-profile.md
@@ -31,9 +31,9 @@ In the pull request to `openshift/ci-tools`, the mapping between a `cluster_prof
 
 ### Providing Credentials
 
-The credentials provided to tests that declare a `cluster_profile` are a mix of content owned by the test platform and content owned by the users adding a new `cluster_profile`. The secret used to hold this content is `cluster-secrets-<name>`, so the `aws` profile uses `cluster-secrets-aws`. When adding a new profile, a pull request must change the `ci-secret-bootstrap` configuration to seed this credential with content owned by the platform, like central pull secrets for image registries ([example](https://github.com/openshift/release/commit/1f775399dfd636a1feca304fb9b6944ca2dd8fb9#diff-5169f2a74d1497f38a44e9adc57f6993269a89c3ddf90ab01f5d1d114ef61e58)). In addition, any user-provided secrets must be added using the [self-service portal](/docs/how-tos/adding-a-new-secret-to-ci/#add-a-new-secret) to add it to the clusters, using the following keys in Vault:
+The credentials provided to tests that declare a `cluster_profile` are a mix of content owned by the test platform and content owned by the users adding a new `cluster_profile`. The secret used to hold this content is `cluster-secrets-<name>`, so the `aws` profile uses `cluster-secrets-aws`. When adding a new profile, a pull request must change the `ci-secret-bootstrap` configuration to seed this credential with content owned by the platform, like central pull secrets for image registries ([example](https://github.com/openshift/release/commit/1f775399dfd636a1feca304fb9b6944ca2dd8fb9#diff-5169f2a74d1497f38a44e9adc57f6993269a89c3ddf90ab01f5d1d114ef61e58)). In addition, any user-provided secrets must be added using the [self-service portal](/docs/how-tos/adding-a-new-secret-to-ci/#add-a-new-secret) to add it to the clusters, using the following keys in Vault (the destination namespace/name needs to match the item added to the `ci-secret-bootstrap` config):
 
 {{< highlight yaml >}}
-secretsync/target-namespace: "test-credentials"
+secretsync/target-namespace: "ci"
 secretsync/target-name: "cluster-secrets-<name>"
 {{< / highlight >}}


### PR DESCRIPTION
The cluster profiles are in `ci` namespace, so the instructions to inject custom secrets into cluster profiles should not mention the `test-credentials` one.