### PR TITLE
content/en/docs/architecture/branching: Automated branching via default branch config

### DIFF
--- a/content/en/docs/architecture/branching.md
+++ b/content/en/docs/architecture/branching.md
@@ -64,7 +64,7 @@ After a release is generally available, we do not require staff engineer lead ap
 Use [this spreadsheet](https://docs.google.com/spreadsheets/u/1/d/19bRYespPb-AvclkwkoizmJ6NZ54p9iFRn6DGD8Ugv2c/edit#gid=0) to view the planned dates but be advised that they may slip, so keep an eye out on the aos-devel mailing list as well.
 
 ## How do I opt my repository into automated branching?
-Ensure that the promotion stanza in your `ci-operator` configuration is pointing to the latest OCP release. For example:
+Ensure that the promotion stanza in your `ci-operator` configuration for your [default branch][default-branch] is pointing to the latest OCP release. For example:
 
 {{< highlight yaml >}}
 promotion:
@@ -86,3 +86,5 @@ Yes. When final freeze happens for release X.Y, the release branch for that vers
 
 ## Do I need to make sure branched CI Operator configs are up to date for release branches?
 No. When the branch is cut and goes live, the current CI Operator configuration for the development branch is used to seed the configuration for the release branch. These are not DRY intentionally to allow for drift between CI for branches.
+
+[default-branch]: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/changing-the-default-branch


### PR DESCRIPTION
Clarify that the `promotion` stanza needs to go in the config for your default branch (e.g. [here][1]), so folks don't think they need an entry in each release branch (although [that's ok too][2], it just doesn't affect future automated branching).

[1]: https://github.com/openshift/release/blob/a1cc80a690ae938516f239d4fd440ae777741207/ci-operator/config/openshift/kubernetes/openshift-kubernetes-master.yaml#L81
[2]: https://github.com/openshift/release/blob/a1cc80a690ae938516f239d4fd440ae777741207/ci-operator/config/openshift/kubernetes/openshift-kubernetes-release-4.9.yaml#L81