### PR TITLE
Set DPTP as exclusive reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,3 +6,12 @@ approvers:
 - petr-muller
 - AlexNPavel
 - alvaroaleman
+- emilvberglind
+- smg247
+reviewers:
+- bbguimaraes
+- droslean
+- hongkailiu
+- petr-muller
+- emilvberglind
+- smg247


### PR DESCRIPTION
This change will avoid selecting Steve, Alvaro and Alex from being assigned to PRs.
