### PR TITLE
Make the GitHub app configuration a step in the process

### DIFF
--- a/content/en/docs/how-tos/onboarding-a-new-component.md
+++ b/content/en/docs/how-tos/onboarding-a-new-component.md
@@ -25,8 +25,7 @@ If your component repository is **not** in this organization:
 	 all prow-controlled repos. This requires `openshift-merge-robot` to be an admin of the repo. We can disable it in
    prow’s [config.yaml](https://github.com/openshift/release/blob/master/core-services/prow/02_config/_config.yaml)
 1. If a repository is [enrolled in centralized branch management](https://docs.ci.openshift.org/docs/architecture/branching/) and no write permissions is granted to `openshift-merge-robot`, ensure that the `tide/merge-blocker` label exists on the repository. Otherwise, [the periodic-openshift-release-merge-blockers job](https://prow.ci.openshift.org/?job=periodic-openshift-release-merge-blockers) would fail. See how to create a label at [Github's documentation](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/creating-a-label).
-
-Additionally, all repositories need the [Openshift CI](https://github.com/apps/openshift-ci) GitHub App installed. We plan to eventually replace the bot accounts entirely
+1. All repositories need the [Openshift CI](https://github.com/apps/openshift-ci) GitHub App installed. Go to the [app](https://github.com/apps/openshift-ci) and click Configure. We plan to eventually replace the bot accounts entirely
 with that app, but that work is not yet done.
 
 


### PR DESCRIPTION
I think this will make it more clear that it is required versus its current placement as a paragraph.