### PR TITLE
content/en/docs/getting-started/examples: Qualify promotion advice

### DIFF
--- a/content/en/docs/getting-started/examples.md
+++ b/content/en/docs/getting-started/examples.md
@@ -47,10 +47,11 @@ continuous integration; a repository opts into using an integration stream with 
 When configuring `ci-operator` for a repository, the `promotion` stanza declares which container `images` are published and
 defines the integration `ImageStream` where they will be available. By default, all container `images` declared in the
 `images` block of a `ci-operator` configuration are published when a `promotion` stanza is present to define the integration
-`ImageStream`. Promotion can be furthermore configured to include other `images`, as well. In the following `ci-operator`
-configuration, the following `images` are promoted for reuse by other repositories to the `ocp/4.4` integration `ImageStream`:
+`ImageStream`. Promotion can be furthermore configured to include other `images`, as well, although promotion should be avoided unless there is an expectation of external consumption. For example, do not publish images with [the `io.openshift.release.operator` label](../../how-tos/onboarding-a-new-component/#product-builds-and-becoming-part-of-an-openshift-release-image) unless they should be included in OpenShift release images.
 
-* the `pipeline:src` tag, published as `ocp/4.4:repo-scripts` containing the latest version of the repository to allow for executing helper scripts
+In the following `ci-operator` configuration, the following `images` are promoted for reuse by other repositories to the `ocp/4.4` integration `ImageStream`:
+
+* the `pipeline:src` tag, published as `ocp/4.4:repo-scripts` containing the latest version of the repository to allow for executing helper scripts.
 * the `pipeline:test-bin` tag, published as `ocp/4.4:repo-tests` containing built test binaries to allow for running the repository's tests
 * the `stable:component` tag, published as `ocp/4.4:component` containing the component itself to allow for deployments and installations in end-to-end scenarios
 


### PR DESCRIPTION
There's no need to promote images that have no known consumer; it just clutters up the target namespace.

And if folks accidentally promote images that ask to be included in OpenShift releases, it can lead to redundant manifests and impact OKD releases, openshift/release#23351.