### PR TITLE
Update the list ordering for pre-submit fields in ci-operator.md

### DIFF
--- a/content/en/docs/architecture/ci-operator.md
+++ b/content/en/docs/architecture/ci-operator.md
@@ -499,9 +499,10 @@ a developer on the content of their pull request and to gate merges to the centr
 when a pull request is opened, when the contents of a pull request are changed, or on demand when a user requests them.
 
 There are few extra fields that can be configured to control if or when the test should be executed.
--`run_if_changed` Set a regex to make the job trigger only when a pull request changes a certain path in the repository (see the [upstream doc](https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#triggering-jobs-based-on-changes)).
--`skip_if_only_changed` Set a regex to skip triggering the job when all the changes in the pull request match (see the [upstream doc](https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#triggering-jobs-based-on-changes)).
--`optional` Set to `true` to `make` the job not block merges.
+
+* `run_if_changed` Set a regex to make the job trigger only when a pull request changes a certain path in the repository (see the [upstream doc](https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#triggering-jobs-based-on-changes)).
+* `skip_if_only_changed` Set a regex to skip triggering the job when all the changes in the pull request match (see the [upstream doc](https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#triggering-jobs-based-on-changes)).
+* `optional` Set to `true` to `make` the job not block merges.
 
 **Note:** `run_if_changed` and `skip_if_only_changed` are mutually exclusive.
 


### PR DESCRIPTION
Update the markdown in ci-operator.md and fix the markdown list item syntax for the individual pre-submit fields being listed so they properly render as list items.

See the previous rendering:

![Screenshot from 2021-11-15 17-32-48](https://user-images.githubusercontent.com/9899409/141863310-c4f51daa-7a3c-4f3b-a80d-57876cd532e9.png)
