### PR TITLE
Document writable /go for build_root

### DIFF
--- a/content/en/docs/architecture/ci-operator.md
+++ b/content/en/docs/architecture/ci-operator.md
@@ -73,7 +73,8 @@ If an image that is required for building is not yet present on the cluster, eit
 ## Build Root Image
 
 The build root image must contain all dependencies for building executables and non-image artifacts. Additionally,
-`ci-operator` requires this image to include a `git` executable in $PATH. Most repositories will want to use an image
+`ci-operator` requires this image to include a `git` executable in $PATH and it has write permission in the folder `/go`.
+Most repositories will want to use an image
 already present in the cluster, using the `image_stream_tag` stanza like described in [Configuring Inputs](#configuring-inputs).
 
 Alternatively, a project can be configured to build a build root image using a `Dockerfile` in the repository:


### PR DESCRIPTION
Follow up https://coreos.slack.com/archives/CBN38N3MW/p1637962019020900?thread_ts=1637953164.013100&cid=CBN38N3MW

`ci-operator` clones the repo to `/go`.
https://github.com/openshift/ci-tools/blob/ef234d3d3c0ae6d26f2d25469b684a8602f691bb/pkg/steps/source.go#L198

That is what we do for ci-tools' boot_image:
https://github.com/openshift/release/blob/1c866e5a7f242d5c8d71627a943525be38fbc4c1/clusters/app.ci/supplemental-ci-images/ci-tools-build-root.yaml#L79

/cc @openshift/test-platform 