### PR TITLE
content/en/docs/how-tos/onboarding-a-new-component: Update ART link

### DIFF
--- a/content/en/docs/how-tos/onboarding-a-new-component.md
+++ b/content/en/docs/how-tos/onboarding-a-new-component.md
@@ -231,8 +231,7 @@ jobs BEFORE you reference them from another component (via the image-references 
 `io.openshift.release.operator` to get automatically included.
 
 1. Ensure you have successfully published your image to the CI integration stream
-1. Follow the [ART instructions](https://mojo.redhat.com/docs/DOC-1179058) to have them build your image
-    * On the [dist-git part of the process](https://mojo.redhat.com/docs/DOC-1168290) it is critical that you ensure your component/image names match as described in the bulleted criteria
+1. Follow the [ART instructions](https://issues.redhat.com/browse/ART-85) to have them build your image.
 1. Ensure a single successful build is run (sync with ART to confirm)
 1. Open the PR to add your new image to another component (your operator, usually)
 1. Once the PR is merged, verify that the [nightly builds](https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/) continue to pass (usually 2-3 hours after your PR merges) and that you didn’t break the OCP CI test


### PR DESCRIPTION
Mojo has been deprecated, and the clone-able ART ticket I'm linking instead opens with:

> First read Guidelines for requesting new content managed by OCP ART (at least "Getting Started" section). There is much to be done before you can use this template.

which links the successor article to the old Mojo page.  I'm also dropping the dist-git warning, because if we need to underline things like that within the ART steps, the most central place for the underlining is the ART instructions themselves.