### PR TITLE
Refuse /payload command on PRs to repositories not contributing to OCP

### DIFF
--- a/content/en/docs/release-oversight/payload-testing.md
+++ b/content/en/docs/release-oversight/payload-testing.md
@@ -8,7 +8,7 @@ The `/payload` command is provided for this purpose.
 
 
 ## Usage
-Any collaborator of the GitHub OpenShift organization can issue the command on any PR to any repository of the organization:
+Any collaborator of the GitHub OpenShift organization can issue the command on a pull request to a branch of a repository of the organization that contributes to OpenShift official images:
 
 > /payload <ocp_version> <ci|nightly> <informing|blocking>
 


### PR DESCRIPTION
/cc @openshift/test-platform 

/hold

Require https://github.com/openshift/ci-tools/pull/2583