### PR TITLE
Fix table_pools' row details

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -97,7 +97,7 @@ function format ( d ) {
           dataType: 'jsonp',
           success: function(res) {
             $.each(res.data, function(index, item) {
-              description=item['product'] + ' ' + item['version'] + ' cluster on ' + item['cloud'];
+              var description=item['product'] + ' ' + item['version'] + ' cluster on ' + item['cloud'];
               if (item['cluster'] === 'app.ci') {
                 description=description+' containing most Prow services.';
               } else if (item['cluster'] === 'hive') {
@@ -112,6 +112,9 @@ function format ( d ) {
           }
       });
 
+  } );
+
+  $(document).ready( function () {
       $.fn.dataTable.ext.errMode = 'throw';
       var table =  $('#table_registries').DataTable({
         "paging":   false,
@@ -138,7 +141,7 @@ function format ( d ) {
             { 
               "data": "description",
               "render": function (data, type, row, meta) {
-                  data="contains up-to-date image copies from the authoritative registry for jobs that run on this build farm only"
+                  var data="contains up-to-date image copies from the authoritative registry for jobs that run on this build farm only"
                   if (row['cluster'] === 'app.ci') {
                     data='the authoritative, central CI registry';
                   } else if (row['cluster'] === 'hive') {


### PR DESCRIPTION
With the PR, the details shows up as expected:
![Screen Shot 2022-01-26 at 10 26 13 AM](https://user-images.githubusercontent.com/4013349/151192878-5c81a4b4-7364-4341-a7ce-8ea75dc3a721.png)

It looks like some variable conflicting (without the PR).
![Screen Shot 2022-01-26 at 10 28 53 AM](https://user-images.githubusercontent.com/4013349/151193343-682a4518-294c-4e70-b21c-2a23cbc0d5fb.png)

Tried to rename some variables but the problem stays.
Moving the function into its own `$(document).ready()` fixes it.

/cc @openshift/test-platform 
