### PR TITLE
how-tos: add more cluster profile instructions

### DIFF
--- a/content/en/docs/how-tos/adding-a-cluster-profile.md
+++ b/content/en/docs/how-tos/adding-a-cluster-profile.md
@@ -11,18 +11,18 @@ about platform enablement process, please see the [OpenShift Infrastructure Prov
 
 {{< /alert >}}
 
-## What a Cluster Profile?
+## What Is a Cluster Profile?
 
 The `cluster_profile` is a `ci-operator` concept that bundles together a couple of concepts to make it easier to configure jobs and steps that can operate on different cloud infrastructures.
 
 When a `cluster_profile` is added to a job or workflow, the following actions occur:
 
-- all steps in the workflow will have [`credentials`](/docs/architecture/step-registry/#injecting-custom-credentials) mounted at `$CLUSTER_PROFILE_DIR` that contains credentials for cloud accounts, image registries, *etc*
+- all steps in the workflow will have [`credentials`](/docs/architecture/step-registry/#injecting-custom-credentials) mounted at `$CLUSTER_PROFILE_DIR` for cloud accounts, image registries, etc.
 - the test will implicitly ask for a [`lease`](/docs/architecture/step-registry/#implicit-lease-configuration-with-cluster_profile) and expose it with `$LEASED_RESOURCE`
 - all steps in the test will implicitly declare [`dependencies`](/docs/architecture/ci-operator/#referring-to-images-in-tests) on imported OpenShift release images
-- all steps will have a number of environment variables set, such a `$CLUSTER_TYPE`, `$IMAGE_FORMAT` and `$KUEBCONFIG`
+- all steps will have a number of environment variables set, such as `$CLUSTER_TYPE`, `$IMAGE_FORMAT`, and `$KUBECONFIG`
 
-Generally, the major difference between `cluster_profile`s is the content of the credentials. These credentials are stored in the test platform clusters using naming convention: `cluster-secrets-<name>`; so, the `aws` profile stores credentials in `cluster-secrets-aws`.
+Generally, the major difference between `cluster_profile`s is the content of the credentials.
 
 ## Adding a New Cluster Profile
 
@@ -34,7 +34,7 @@ As `cluster-profile`s are handled as first-class items in the `ci-operator` conf
 
 ### Adding New Leases
 
-In the pull request to `openshift/ci-tools`, the mapping between a `cluster_profile` and the implcit `lease` that will be requested is determined. The standard is to use leases named `<name>-quota-slice`, so the `aws` profile uses `aws-quota-slice`. The resources for leasing must be [registered](/docs/architecture/quota-and-leases/#adding-a-new-type-of-resource) with our leasing server ([example](https://github.com/openshift/release/commit/1f775399dfd636a1feca304fb9b6944ca2dd8fb9#diff-5169f2a74d1497f38a44e9adc57f6993269a89c3ddf90ab01f5d1d114ef61e58)).
+In the pull request to `openshift/ci-tools`, the mapping between a `cluster_profile` and the implicit `lease` that will be requested is determined. The standard is to use leases named `<name>-quota-slice`, so the `aws` profile uses `aws-quota-slice`. The resources for leasing must be [registered](/docs/architecture/quota-and-leases/#adding-a-new-type-of-resource) with our leasing server ([example](https://github.com/openshift/release/commit/1f775399dfd636a1feca304fb9b6944ca2dd8fb9#diff-5169f2a74d1497f38a44e9adc57f6993269a89c3ddf90ab01f5d1d114ef61e58)).
 
 ### Providing Credentials
 

--- a/content/en/docs/how-tos/adding-a-cluster-profile.md
+++ b/content/en/docs/how-tos/adding-a-cluster-profile.md
@@ -17,11 +17,11 @@ The `cluster_profile` is a `ci-operator` concept that bundles together a couple 
 
 When a `cluster_profile` is added to a job or workflow, the following actions occur:
 
- - all steps in the workflow will have [`credentials`](/docs/architecture/step-registry/#injecting-custom-credentials) mounted at `$CLUSTER_PROFILE_DIR` that contains credentials for cloud accounts, image registries, *etc*
- - the test will implicitly ask for a [`lease`](/docs/architecture/step-registry/#implicit-lease-configuration-with-cluster_profile) and expose it with `$LEASED_RESOURCE`
- - all steps in the test will implicitly declare [`dependencies`](/docs/architecture/ci-operator/#referring-to-images-in-tests) on imported OpenShift release images
- - all steps will have a number of environment variables set, such a `$CLUSTER_TYPE`, `$IMAGE_FORMAT` and `$KUEBCONFIG`
- 
+- all steps in the workflow will have [`credentials`](/docs/architecture/step-registry/#injecting-custom-credentials) mounted at `$CLUSTER_PROFILE_DIR` that contains credentials for cloud accounts, image registries, *etc*
+- the test will implicitly ask for a [`lease`](/docs/architecture/step-registry/#implicit-lease-configuration-with-cluster_profile) and expose it with `$LEASED_RESOURCE`
+- all steps in the test will implicitly declare [`dependencies`](/docs/architecture/ci-operator/#referring-to-images-in-tests) on imported OpenShift release images
+- all steps will have a number of environment variables set, such a `$CLUSTER_TYPE`, `$IMAGE_FORMAT` and `$KUEBCONFIG`
+
 Generally, the major difference between `cluster_profile`s is the content of the credentials. These credentials are stored in the test platform clusters using naming convention: `cluster-secrets-<name>`; so, the `aws` profile stores credentials in `cluster-secrets-aws`.
 
 ## Adding a New Cluster Profile

--- a/content/en/docs/how-tos/onboarding-a-new-component.md
+++ b/content/en/docs/how-tos/onboarding-a-new-component.md
@@ -46,7 +46,7 @@ make new-repo
 {{< / highlight >}}
 
 This should fully configure your repository, so the changes that it produces are ready to be submitted in a pull
-request. The resulting yaml file called `$org-$repo-$branch.yaml`
+request. The resulting YAML file called `$org-$repo-$branch.yaml`
 will be found in the `ci-operator/config/$org/$repo` directory.
 
 


### PR DESCRIPTION
Based on recent changes in `ci-tools` which tried to make this process as
simple as possible.  This area has been kept intentionally obscure but,
with no immediate plan for deprecation, there's no reason to make users
(and `dptp-helpdesk`, by extension) suffer.

/hold

To be merged after all `ci-tools` changes.

- [x] https://github.com/openshift/ci-tools/pull/2751
- [x] https://github.com/openshift/ci-tools/pull/2752
- [x] https://github.com/openshift/ci-tools/pull/2753
- [x] https://github.com/openshift/ci-tools/pull/2756