### PR TITLE
content/en/docs: Services and step-docs links to steps.ci

### DIFF
--- a/content/en/docs/architecture/step-registry.md
+++ b/content/en/docs/architecture/step-registry.md
@@ -8,6 +8,8 @@ These individual steps can be put into a shared registry that other tests can ac
 upgrade as multiple test workflows can share steps and don’t have to each be updated individually to fix bugs or add new features. It also reduces the
 chances of a mistake when copying a feature from one test workflow to another.
 
+The current step registry is available for browsing [here](https://steps.ci.openshift.org/).
+
 To understand how the multistage tests and registry work, we must first talk about the three components of the test registry and how to use those
 components to create a test:
 

--- a/content/en/docs/getting-started/useful-links.md
+++ b/content/en/docs/getting-started/useful-links.md
@@ -27,6 +27,7 @@ Below is a non-exhaustive list of CI services.
 * [search.ci.openshift.org](https://search.ci.openshift.org/): search tool for error messages in job logs and Bugzilla bugs.
 * [sippy.dptools.openshift.org](https://sippy.dptools.openshift.org/): CI release health summary.
 * [bugs.ci.openshift.org](https://bugs.ci.openshift.org/): Bugzilla bug overviews, backporting and release viewer.
+* [steps.ci.openshift.org](https://steps.ci.openshift.org/): [Step registry](/docs/architecture/step-registry/) viewer.
 
 # Contact
 

--- a/content/en/docs/getting-started/useful-links.md
+++ b/content/en/docs/getting-started/useful-links.md
@@ -25,7 +25,7 @@ Below is a non-exhaustive list of CI services.
 * [multi.ocp.releases.ci.openshift.org](https://multi.ocp.releases.ci.openshift.org/): OCP Multi-arch release status page.
 * [amd64.origin.releases.ci.openshift.org](https://amd64.origin.releases.ci.openshift.org/): OKD release status page.
 * [search.ci.openshift.org](https://search.ci.openshift.org/): search tool for error messages in job logs and Bugzilla bugs.
-* [sippy.ci.openshift.org](https://sippy.ci.openshift.org/): CI release health summary.
+* [sippy.dptools.openshift.org](https://sippy.dptools.openshift.org/): CI release health summary.
 * [bugs.ci.openshift.org](https://bugs.ci.openshift.org/): Bugzilla bug overviews, backporting and release viewer.
 
 # Contact


### PR DESCRIPTION
There's already a link in the header/menu via config.yaml, but while hunting for this service in docs recently I realized that I apparently skim by the header without actually reading it.  Put some more links in likely places as a backstop for other folks also skimming past the header.

While I'm touching things, also update to sippy.dptools to catch up with openshift/release#28039.