### PR TITLE
artifacts: fix link

### DIFF
--- a/content/en/docs/how-tos/artifacts.md
+++ b/content/en/docs/how-tos/artifacts.md
@@ -76,7 +76,7 @@ The middle of the page contains the main build log.  Particular error patterns
 are highlighted and the full output is initially folded so that only relevant
 parts are displayed.  For `ci-operator` jobs, this section contains the log
 messages of level `info` and above from its output, described [below]({{< ref
-"#ci-operator-output" >}}).  The "raw build-log.txt" link contains the same
+"#ci-operator-artifacts" >}}).  The "raw build-log.txt" link contains the same
 text, but served as a regular text file, and is also available as
 `build-log.txt` in the artifacts directory.
 


### PR DESCRIPTION
Missed previously due to the extreme noise in the `links` job.

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-docs/233/pull-ci-openshift-ci-docs-master-links/1554064037258465280#1:build-log.txt%3A24-25