### PR TITLE
Add a warning about mirroring from docker.io

### DIFF
--- a/content/en/docs/how-tos/external-images.md
+++ b/content/en/docs/how-tos/external-images.md
@@ -16,6 +16,10 @@ If the source image is open to the public, we can mirror the image by adding it 
 gcr.io/k8s-staging-boskos/boskos:latest registry.ci.openshift.org/ci/boskos:latest
 {{< / highlight >}}
 
+{{< alert title="Warning" color="warning" >}}
+We cannot mirror images from `docker.io` due to rate limiting constraints. Please, instead, push up an image to quay and mirror that to the CI registry.
+{{< /alert >}}
+
 The hourly periodic job [`periodic-image-mirroring-supplemental-ci-images`](https://prow.ci.openshift.org/?job=periodic-image-mirroring-supplemental-ci-images)
 mirrors all the images defined in the mapping files.  Note that it operates on
 the contents of the `master` branch, so the changes to the files have to be


### PR DESCRIPTION
People occasionally try to mirror an image from `docker.io` and we always have issues with it. Most recent problem: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-image-mirroring-supplemental-ci-images/1559555641926750208