### PR TITLE
content/en/docs/architecture/ci-operator-internals/observer-pods: Wait-for-KUBECONFIG

### DIFF
--- a/content/en/docs/architecture/ci-operator-internals/observer-pods.md
+++ b/content/en/docs/architecture/ci-operator-internals/observer-pods.md
@@ -212,9 +212,11 @@ at the path specified in `$KUBECONFIG`.
 
 It is safe to check for its existence or not by invoking the following code:
 {{< highlight bash >}}
-if [ -f "$KUBECONFIG" ]; then
-    ...
-fi
+while [ ! -f "${KUBECONFIG}" ]; do
+  printf "%s: waiting for %s\n" "$(date --utc --iso=s)" "${KUBECONFIG}"
+  sleep 10
+done
+printf "%s: acquired %s\n" "$(date --utc --iso=s)" "${KUBECONFIG}"
 {{< / highlight >}}
 
 Kubeconfig is treated differently from `$SHARED_DIR`, so observers could receive it at any time. Please do not make any assumptions about the order of events.


### PR DESCRIPTION
It seems unlikely that observers would do something in the presence of kubeconfig, but be fine skipping that thing in its absence.  Pivot the example to a poll loop that will wait until a kubeconfig is available.  Personally I'd like gathered step logs to use `--timestamps`, but in the absence of that, I'm manually including timestamps in my output lines to make it easier to tell when the kubeconfig shows up.

Follows up on #287, CC @danilo-gemoli