### PR TITLE
slack-alerts: note on private channels

### DIFF
--- a/content/en/docs/how-tos/notification.md
+++ b/content/en/docs/how-tos/notification.md
@@ -17,6 +17,7 @@ reporter_config:
 For example, by the above snippet, a Slack alert will be sent out to `#forum` channel when there is a failure of the job. The alert is formatted by `report_template`.
 
 * The channel has to be in [coreos.slack.com](https://coreos.slack.com/).
+* The channel has to be public. If it is not then the `@prow` bot has to be added to it otherwise it won't be able to properly post messages.
 * The state in `job_states_to_report` has to be a valid Prow job state. See [upstream documentation](https://godoc.org/k8s.io/test-infra/prow/apis/prowjobs/v1#ProwJobState).
 * The value of `report_template` is a [Go template](https://golang.org/pkg/text/template/) and it will be applied to the Prow job instance. The annotations such as `{{.Spec.Job}}` will be replaced by the job name when the alert is received in Slack. See [upstream documentation](https://godoc.org/k8s.io/test-infra/prow/apis/prowjobs/v1#ProwJob) for more fields of a Prow job. Note that no alerts will be sent out if the template is broken, e.g., cannot be parsed or applied successfully.
 


### PR DESCRIPTION
Improve documentation on Slack alerts: how to deal with private channels.
I have found several errors from `crier` like the following:
`msg=failed to write Slack message, error=failed to post message to #kata-ocp-ci-reports: request failed: channel_not_found`
That's due the channel not being public, therefore ` @prow` is not able to post on it.
/cc @bbguimaraes 