### PR TITLE
`pj-rehearse` updates: abort, re-trigger individual rehearsals, and warn about hidden

### DIFF
--- a/content/en/docs/how-tos/contributing-openshift-release.md
+++ b/content/en/docs/how-tos/contributing-openshift-release.md
@@ -115,7 +115,7 @@ The following changes are considered when triggering rehearsals:
 1. Changes to cluster profiles (`cluster/test-deploy`)
 
 Rerunning rehearsals can be done by re-triggering the plugin: `/pj-rehearse`, which then triggers all rehearsals of jobs currently
-affected by the PR, including the rehearsals that passed before. Individual rehearsals can also be re-triggered by utilizing the ['Rehearse Specific Jobs'](#rehearse-specific-jobs) functionality.
+affected by the PR, including the rehearsals that passed before. Individual rehearsals can also be re-triggered by utilizing the [Rehearse Specific Jobs](#rehearse-specific-jobs) functionality.
 
 Certain changes affect many jobs. For example, when a template or a step used by many jobs is changed, in theory all
 these jobs could be affected by the change, but it is unrealistic to rehearse them all. In some of these cases,

--- a/content/en/docs/how-tos/contributing-openshift-release.md
+++ b/content/en/docs/how-tos/contributing-openshift-release.md
@@ -86,6 +86,7 @@ All pull requests trigger a `pj-rehearse` external prow plugin. It checks the ch
 * `/pj-rehearse more` to run up to 20 rehearsal jobs from the list
 * `/pj-rehearse max` to run up to 35 rehearsal jobs from the list
 * `/pj-rehearse refresh` to obtain an updated list of affected jobs. This is useful in the event that the PR branch is pushed to
+* `/pj-rehearse abort` to abort all active rehearsals
 * `/pj-rehearse skip` to opt-out of rehearsals for the PR, and add the `rehearsals-ack` label
 * `/pj-rehearse ack` to acknowledge the rehearsals (pass or fail), and add the `rehearsals-ack` label
 * `/pj-rehearse reject` to remove the `rehearsals-ack` label and re-block merging

--- a/content/en/docs/how-tos/contributing-openshift-release.md
+++ b/content/en/docs/how-tos/contributing-openshift-release.md
@@ -113,9 +113,8 @@ The following changes are considered when triggering rehearsals:
 1. Changes to templates (`ci-operator/templates`)
 1. Changes to cluster profiles (`cluster/test-deploy`)
 
-It is not possible to rerun individual rehearsal jobs. They do not react to any trigger commands. Rerunning rehearsals
-must be done by re-triggering the plugin: `/pj-rehearse`, which then triggers all rehearsals of jobs currently
-affected by the PR, including the rehearsals that passed before.
+Rerunning rehearsals can be done by re-triggering the plugin: `/pj-rehearse`, which then triggers all rehearsals of jobs currently
+affected by the PR, including the rehearsals that passed before. Individual rehearsals can also be re-triggered by utilizing the ['Rehearse Specific Jobs'](#rehearse-specific-jobs) functionality.
 
 Certain changes affect many jobs. For example, when a template or a step used by many jobs is changed, in theory all
 these jobs could be affected by the change, but it is unrealistic to rehearse them all. In some of these cases,
@@ -149,6 +148,10 @@ rehearsals:
 
 Either of the preceding configurations will result in the `pj-rehearse.openshift.io/can-be-rehearsed: "true"` label not 
 being added to the affected jobs when running `make jobs`.
+
+{{< alert title="Warning" color="warning" >}}
+Jobs that are marked as `hidden: true` will never be rehearsed, regardless of the presence of the `pj-rehearse.openshift.io/can-be-rehearsed: "true"` label.
+{{< /alert >}}
 
 ### `ci-operator` Configuration Sharding
 


### PR DESCRIPTION
/cc @openshift/test-platform 