### PR TITLE
Remove an expired build link

### DIFF
--- a/content/en/docs/how-tos/artifacts.md
+++ b/content/en/docs/how-tos/artifacts.md
@@ -80,7 +80,7 @@ messages of level `info` and above from its output, described [below]({{< ref
 text, but served as a regular text file, and is also available as
 `build-log.txt` in the artifacts directory.
 
-In the case of the example job, the [build log](https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_ci-tools/2877/pull-ci-openshift-ci-tools-master-unit/1539279980293263360/build-log.txt)
+In the case of the example job, the build log
 was as follows (parts of it will be used in examples in this and the next
 sections).
 


### PR DESCRIPTION
```console
curl https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_ci-tools/2877/pull-ci-openshift-ci-tools-master-unit/1539279980293263360/build-log.txt
<?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: origin-ci-test/pr-logs/pull/openshift_ci-tools/2877/pull-ci-openshift-ci-tools-master-unit/1539279980293263360/build-log.txt</Details></Error>%
```

The artifacts' retention is 180d which is configured on the GCP bucket.
So we cannot use the link there.

/cc @openshift/test-platform 