### PR TITLE
Provide another way to get the registry authfile

### DIFF
--- a/content/en/docs/how-tos/use-registries-in-build-farm.md
+++ b/content/en/docs/how-tos/use-registries-in-build-farm.md
@@ -147,8 +147,12 @@ registry. Make sure your `oc` CLI is [logged in](#how-do-i-log-in-to-pull-images
 `app.ci` cluster via the [console](https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/), then you
 will be able to generate the pull credentials for your `ServiceAccount` using the `oc` CLI:
 
-```bash
-$ oc --namespace my-project registry login --service-account image-puller --registry-config=/tmp/config.json
+```console
+### Require jq cmd: https://stedolan.github.io/jq/
+$ oc registry login --auth-basic $(oc get secrets -n my-project --sort-by=.metadata.creationTimestamp -o json | \
+  jq '.items[] | select(.type=="kubernetes.io/dockercfg" and .metadata.annotations["kubernetes.io/service-account.name"]=="image-puller")' | \
+  jq -r -s '.[-1] | .data.".dockercfg"' | base64 -d | jq -r '."registry.ci.openshift.org" as $e | $e.username + ":" + $e.password') \
+  --registry-config=/tmp/config.json
 ```
 
 The created `/tmp/config.json` file can be then used as a standard `.docker/config.json` authentication file.


### PR DESCRIPTION
https://issues.redhat.com/browse/DPTP-3265

- `oc registry login --service-account` does not work any more.

- jsonpath of `kubectl` does not support logic and operator. Otherwise, we might not need `jq`.

- The `.dockercfg` file is not recognized by `podman 4.0.0` (I tested it). Otherwise, we might not need `oc registry login`.

[k8s doc](https://kubernetes.io/docs/concepts/configuration/secret/#docker-config-secrets) says 

"The kubernetes.io/dockercfg type is reserved to store a serialized ~/.dockercfg which is the legacy format for configuring Docker command line."

I am not sure why k8s/openshift still uses it to format the auth file since it is legacy and not recognized by `podman`.