### PR TITLE
useful-links: add cluster error message

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -99,6 +99,10 @@ function format ( d ) {
           success: function(res) {
             $.each(res.data, function(index, item) {
               var description=item['product'] + ' ' + item['version'] + ' cluster on ' + item['cloud'];
+              if (item['error'] !== "") {
+                  $("#ul_clusters").append('<li>' + item["cluster"] + ': ' + item['error'] + '</li>');
+                  return;
+              }
               if (item['cluster'] === 'app.ci') {
                 description=description+' containing most Prow services.';
               } else if (item['cluster'] === 'hive') {

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -98,11 +98,11 @@ function format ( d ) {
           dataType: 'jsonp',
           success: function(res) {
             $.each(res.data, function(index, item) {
-              var description=item['product'] + ' ' + item['version'] + ' cluster on ' + item['cloud'];
               if (item['error'] !== "") {
-                  $("#ul_clusters").append('<li>' + item["cluster"] + ': ' + item['error'] + '</li>');
-                  return;
+                $("#ul_clusters").append('<li>' + item["cluster"] + ': ' + item['error'] + '</li>');
+                return;
               }
+              var description=item['product'] + ' ' + item['version'] + ' cluster on ' + item['cloud'];
               if (item['cluster'] === 'app.ci') {
                 description=description+' containing most Prow services.';
               } else if (item['cluster'] === 'hive') {


### PR DESCRIPTION
Shows a message if there was an error while gathering info about a cluster (due to broken kubeconfig or anything else). The rest of the clusters are listed normally.
Back end changes were done in https://github.com/openshift/ci-tools/pull/3220.

for https://issues.redhat.com/browse/DPTP-3086

/cc smg247