### PR TITLE
Cluster display needs to check for `undefined`

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -98,7 +98,7 @@ function format ( d ) {
           dataType: 'jsonp',
           success: function(res) {
             $.each(res.data, function(index, item) {
-              if (item['error'] !== "") {
+              if (item['error']) {
                 $("#ul_clusters").append('<li>' + item["cluster"] + ': ' + item['error'] + '</li>');
                 return;
               }


### PR DESCRIPTION
Since https://github.com/openshift/ci-tools/pull/3241 we cannot do a strict empty string comparison.