### PR TITLE
Cannot claim non-released clusters

### DIFF
--- a/content/en/docs/architecture/ci-operator.md
+++ b/content/en/docs/architecture/ci-operator.md
@@ -493,6 +493,12 @@ The payload of the release is the one used to install the ephemeral cluster for 
 That means if there is a release in the `releases` stanza with the same name, it is overridden throughout the test.
 To avoid the release overriding, `cluster_claim.as` can be given as a value which does not appear in the `releases` stanza.
 
+The version of the claimed cluster is determined by the reference to a `ClusterImageSet` of the cluster pool
+which defines the image that contains the payload to use when installing a cluster.
+The _released_ `4.Y` versions of `ClusterImageSet` [manifests](https://github.com/openshift/release/tree/master/clusters/hive/pools) are maintained by
+a tool which ensures that they points to the latest version.
+It is currently not supported that a test claims by `cluster_claim` a cluster with the version which has not been released yet.
+
 ## Declaring Tests
 
 Tests as executed by `ci-operator` run a set of commands inside of a container; this is implemented by scheduling a `Pod`


### PR DESCRIPTION
Follow up https://redhat-internal.slack.com/archives/CBN38N3MW/p1676646286837089

/cc @openshift/test-platform @asergienk 

Besides the tool, there are other things that we need to consider if we want remove the limitation, e.g., the pull secret to pull the images in the payload.