### PR TITLE
Revert "links image: install bash"

### DIFF
--- a/Dockerfile.links
+++ b/Dockerfile.links
@@ -7,5 +7,3 @@ RUN set -x && ln -s /bin/bash /usr/bin/bash && make generate
 FROM klakegg/html-proofer:3.18.5
 
 COPY --from=builder /src/public/ /src/public/
-
-RUN apk add --no-cache bash


### PR DESCRIPTION
This reverts commit a8d562541295357cba2e166a8b52ac4cf6953b19.

Move the step to base image.
https://github.com/openshift/release/pull/36568/files
