### PR TITLE
Cluster Profile: "Adding New Leases" example PR needs no reaper anymore

### DIFF
--- a/content/en/docs/how-tos/adding-a-cluster-profile.md
+++ b/content/en/docs/how-tos/adding-a-cluster-profile.md
@@ -65,7 +65,7 @@ type unless they require special treatment in the installation process.
 
 ### Adding New Leases
 
-In the pull request to `openshift/ci-tools`, the mapping between a `cluster_profile` and the implicit `lease` that will be requested is determined. The standard is to use leases named `<name>-quota-slice`, so the `aws` profile uses `aws-quota-slice`. The resources for leasing must be [registered](/docs/architecture/quota-and-leases/#adding-a-new-type-of-resource) with our leasing server ([example](https://github.com/openshift/release/pull/27033)).
+In the pull request to `openshift/ci-tools`, the mapping between a `cluster_profile` and the implicit `lease` that will be requested is determined. The standard is to use leases named `<name>-quota-slice`, so the `aws` profile uses `aws-quota-slice`. The resources for leasing must be [registered](/docs/architecture/quota-and-leases/#adding-a-new-type-of-resource) with our leasing server ([example](https://github.com/openshift/release/pull/32536)).
 
 ### Providing Credentials
 


### PR DESCRIPTION
The Reaper reads resource types from the same configuration file of Boskos, see [here](https://github.com/openshift/release/blob/6f16ca30d33ea8c700e1100e3e930a0dc1a5636c/clusters/app.ci/prow/03_deployment/boskos_reaper.yaml#L26), since [#36642](https://github.com/openshift/release/pull/36642) has been merged.
Documentation has to be updated accordingly. 