### PR TITLE
Reference the new `stream` location

### DIFF
--- a/content/en/docs/architecture/ci-operator.md
+++ b/content/en/docs/architecture/ci-operator.md
@@ -429,8 +429,8 @@ releases:
   ec:
     prerelease:       # references a version known to a release controller
       product: ocp
-      stream: 4-dev-preview
       version_bounds: # bounds the version for the release chosen
+        stream: 4-dev-preview
         lower: "4.1.0"
         upper: "4.999.0"
 {{< / highlight >}}


### PR DESCRIPTION
`stream` was moved within `version_bounds` in https://github.com/openshift/ci-tools/pull/3314