### PR TITLE
Clarify mirroring external private images

### DIFF
--- a/content/en/docs/how-tos/external-images.md
+++ b/content/en/docs/how-tos/external-images.md
@@ -41,6 +41,4 @@ base_images:
 
 ## Mirror Private Images
 
-If the image is in a private registry that requires authentication to pull it, you will need to [add your credentials](/docs/how-tos/adding-a-new-secret-to-ci/) and define a new periodic [mirroring job](/docs/how-tos/mirroring-to-quay/) with it.
-
-We cannot reuse the existing job as the keys in the credentials config are registries and we might have to set up multiple credentials for the same registry.
+It is not supported at the moment to mirror external private images to the central CI registry.


### PR DESCRIPTION
In theory it is as simple as setting up this job.
periodic-image-mirroring-supplemental-ci-private-images-redhat
https://github.com/openshift/release/blob/62bd02cec4d1bb02ae9c7d21794a2cf929435c4e/ci-operator/jobs/infra-image-mirroring.yaml#L963

However, it is not practical:
In case the target image could be public (very odd because the source cannot be public in the first place), the image has to set up a new namespace and push credentials for that namespace. The namespace cannot be `ci` because it could impact other images in `ci`.

In case the target image stays private, in additional to the above credentials, the ci-operator on other build-farms need to have access to importing the image to the testing namespace.

We probably need a design and automation for the case.