### PR TITLE
Note restrictions on `openshift-ci` pools to `openshift` org

### DIFF
--- a/content/en/docs/architecture/timeouts.md
+++ b/content/en/docs/architecture/timeouts.md
@@ -145,7 +145,7 @@ ref:
 ```
 
 {{< alert title="Note" color="info" >}}
-The `pod.spec.activeDeadlineSeconds` setting on a `Pod` only implicitly bounds the amount of time that a `Pod` executes for on a Kubernetes cluster. The active deadline begins at the first moment that a `kubelet` acknowledges the `Pod`, which is after it is scheduled to a specific node but before it pulls images, sets up a container sandbox, _etc_. It is therefore possible to exceed the active deadline without ever having a container in the `Pod` execute. Please see the [API documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podspec-v1-core) for more details. For these reasons, no timeout configured in the system makes use of this setting, instead relying on a thin wrapper around the executing code that's injected by Prow itself.
+The `pod.spec.activeDeadlineSeconds` setting on a `Pod` only implicitly bounds the amount of time that a `Pod` executes for on a Kubernetes cluster. The active deadline begins at the first moment that a `kubelet` acknowledges the `Pod`, which is after it is scheduled to a specific node but before it pulls images, sets up a container sandbox, _etc_. It is therefore possible to exceed the active deadline without ever having a container in the `Pod` execute. Please see the [API documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podspec-v1-core) for more details. For these reasons, no timeout configured in the system makes use of this setting, instead relying on a thin wrapper around the executing code that's injected by Prow itself.
 {{< /alert >}}
 
 ## How Interruptions May Be Handled

--- a/content/en/docs/how-tos/cluster-claim.md
+++ b/content/en/docs/how-tos/cluster-claim.md
@@ -322,8 +322,8 @@ from [the status and the specification of each pool](https://pkg.go.dev/github.c
 details of the cluster pool, such as the release image that is used for provisioning a cluster and the labels defined on
 the pool. The Search box can filter out the pools according to the given keyword.
 
-The cluster pools owned by `openshift-ci` are general-purpose pools maintained by DPTP
-and they can be used by anyone. Pools with different owners should be used only with
+The cluster pools owned by `openshift-ci` are general-purpose pools for OpenShift workloads maintained by DPTP
+and they can be used by any tests in the `openshift` org. Pools with different owners should be used only with
 knowledge and approval of their owner. This is not currently programmaticaly enforced
 but it will be soon.
 

--- a/content/en/docs/how-tos/cluster-claim.md
+++ b/content/en/docs/how-tos/cluster-claim.md
@@ -322,7 +322,7 @@ from [the status and the specification of each pool](https://pkg.go.dev/github.c
 details of the cluster pool, such as the release image that is used for provisioning a cluster and the labels defined on
 the pool. The Search box can filter out the pools according to the given keyword.
 
-The cluster pools owned by `openshift-ci` are general-purpose pools for OpenShift workloads maintained by DPTP
+The cluster pools owned by `openshift-ci` are for OpenShift workloads, maintained by DPTP,
 and they can be used by any tests in the `openshift` org. Pools with different owners should be used only with
 knowledge and approval of their owner. This is not currently programmaticaly enforced
 but it will be soon.


### PR DESCRIPTION
We shouldn't keep allowing anyone to use these. These really should only be used by the `openshift` org.

Also updated a dead link to the latest version.