### PR TITLE
`boskos`: Reaper config update not needed anymore

### DIFF
--- a/content/en/docs/architecture/quota-and-leases.md
+++ b/content/en/docs/architecture/quota-and-leases.md
@@ -71,11 +71,6 @@ The `default` key is a special identifier for declaring dynamic resources; use d
 If it is not clear exactly how many concurrent jobs can share the cloud provider at once, the convention is to set the
 `default` count to `1000`, to effectively leave jobs unlimited and allow for investigation.
 
-In addition to registering the volume of concurrent jobs that are allowed against a new cloud platform, it is required
-that the leasing server is configured to reap leases which have not seen a recent heartbeat. This is done by adding the
-name of the resource type to the
-[reaper's configuration](https://github.com/openshift/release/blob/e5a0ae275001b08192a2b9e70587bba1e71f29a6/clusters/app.ci/prow/03_deployment/boskos_reaper.yaml#L26).
-
 ## Configuration for Heterogeneous Resources
 
 The example configuration above will create dynamic resources and is most appropriate for operating against large cloud


### PR DESCRIPTION
Thanks to [kubernetes-sigs/boskos#157](https://github.com/kubernetes-sigs/boskos/pull/157) there is no need to keep the `reaper`'s config in sync with the `boskos`'s one anymore.

/cc @smg247 