### PR TITLE
Show status for ajax calls on clusters

### DIFF
--- a/content/en/docs/getting-started/useful-links.md
+++ b/content/en/docs/getting-started/useful-links.md
@@ -8,6 +8,7 @@ weight: 1
 The clusters that currently comprise CI are:
 
 {{< rawhtml >}}
+<div id="progress">Loading Cluster information ...</div>
 <ul id="ul_clusters">
 </ul>
 {{< /rawhtml >}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -113,8 +113,12 @@ function format ( d ) {
                 description=description+' that executes a growing subset of the jobs.'
               }
               $("#ul_clusters").append('<li><a href="https://'+item["consoleHost"]+'/">'+item["cluster"]+'</a>: '+ description +'</li>');
+              $("#progress").hide();
             });
-          }
+          },
+          error: function(xhr) { 
+            $("#progress").text('failed to load the cluster info: status ' + xhr.status);
+          },
       });
 
   } );


### PR DESCRIPTION
<img width="1069" alt="Screenshot 2023-09-25 at 11 17 56 PM" src="https://github.com/openshift/ci-docs/assets/4013349/fc7b857b-8ec7-4e6e-8e4e-7ca46c8e86ad">

As shown with the above image, our fix should work when some cluster is not available.

However, at the recent outage, we still cannot see the whole section of cluster. This might be caused by `cluster-display` crashed. I did not get the chance to debug further during the outage.

With the PR, if I do not start `cluster-display` at all:
![Screenshot 2023-09-26 at 2 37 40 PM](https://github.com/openshift/ci-docs/assets/4013349/261c939e-fbff-47ac-8f52-d132a567c381)

/cc @psalajova @smg247 
