### PR TITLE
Emphasize GitHub link in Rover People

### DIFF
--- a/content/en/docs/getting-started/useful-links.md
+++ b/content/en/docs/getting-started/useful-links.md
@@ -16,6 +16,11 @@ The clusters that currently comprise CI are:
 Except the ones not managed by DPTP, Red Hat SSO is enabled to login onto these clusters.
 GitHub Users in OpenShift organization who have no Red Hat SSO can still use Prow services to do CI tasks but they cannot login into these clusters.
 
+## Configure GitHub in Rover People
+For user permissions correctly set up on the CI clusters, it is required that the *GITHUB* user profile is configured in Rover People under
+*PROFESSIONAL SOCIAL MEDIA* as the last or only github link. It may take up to 24 hours to synchronize the modification
+at Rover People to the clusters.
+
 # Services
 
 Below is a non-exhaustive list of CI services.

--- a/content/en/docs/how-tos/interact-with-running-jobs.md
+++ b/content/en/docs/how-tos/interact-with-running-jobs.md
@@ -50,13 +50,7 @@ simultaneously are also compatible.
 
 It is possible to authenticate to CI build farms with Red Hat Single-Sign-On:
 The corresponding Red Hat kerberos ID to the author of a pull request
-is permitted to accessing the `Namespace` that run jobs.
-
-{{< alert title="Info" color="info" >}}
-To access the `Namespace` it is required that your *GITHUB* user profile is configured in Rover People under 
-*PROFESSIONAL SOCIAL MEDIA* as the last or only github link. It may take up to 24 hours to synchronize the modification 
-at Rover People to the build farms.
-{{< /alert >}}
+is permitted to accessing the `Namespace` that run jobs provided that [GitHub is properly set up in Rover People](/docs/getting-started/useful-links/#configure-github-in-rover-people).
 
 From a pull request page on GitHub, you can access the build logs from the `Details` link next to each job listed in the
 checkbox at the bottom of the PR description page. This gives an overall picture of the test output, but you might want


### PR DESCRIPTION
We will have more and more automation depending on the GitHub link in Rover People and thus we move the information to a more visible place.
https://issues.redhat.com/browse/DPTP-3328

/cc @openshift/test-platform
/assign @Prucek 