### PR TITLE
Clean up the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 public/
 resources/_gen
 .hugo_build.lock
+node_modules/

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,7 +16,6 @@
 {{ partialCached "favicons.html" . }}
 <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
 {{- template "_internal/opengraph.html" . -}}
-{{- template "_internal/google_news.html" . -}}
 {{- template "_internal/schema.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}
 {{ if hugo.IsProduction }}


### PR DESCRIPTION
- `node_modules/` is the folder generated on the dev env to store the dependencies. They should not be pushed to Git repo.
- It already caused issues with higher version of Hugo or NodeJS. Let us see if we can remove it even in the lower version.