### PR TITLE
Update step-registry.md

### DIFF
--- a/content/en/docs/architecture/step-registry.md
+++ b/content/en/docs/architecture/step-registry.md
@@ -199,6 +199,9 @@ ref:
     The step runs with custom credentials injected.
 {{< / highlight >}}
 
+Note: For most cases, there won't be enough permissions to write the secrets under /var/run/ and therefore it is advised to instead save the secrets 
+to the /secrets/ folder.
+
 {{< alert title="Warning" color="warning" >}}
 Access to read these secrets from the namespace configured must be granted separately from the configuration being added to a step.
 By default, only secrets in the `test-credentials` namespace will be available for mounting into test steps. Please follow the secret-management


### PR DESCRIPTION
Added note to advise users not to save secrets under /var/run due to lack of writting permissions in that folder. https://redhat-internal.slack.com/archives/CBN38N3MW/p1696592984970319 for context