### PR TITLE
timeouts.md: remove exits

### DIFF
--- a/content/en/docs/architecture/timeouts.md
+++ b/content/en/docs/architecture/timeouts.md
@@ -183,7 +183,6 @@ current=0
 
 function cleanup() {
   echo "Validated up to ${current}!"
-  exit 1
 }
 trap cleanup EXIT
 
@@ -216,7 +215,6 @@ function cleanup() {
   done
   wait
   echo "Validated up to ${current}!"
-  exit 1
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
For folks that cargo-cult these blocks, the `exit 1` will cause their tests to perma-fail. Don't ask me how I know.