### PR TITLE
promotion: support multiple targets

### DIFF
--- a/content/en/docs/architecture/branching.md
+++ b/content/en/docs/architecture/branching.md
@@ -68,8 +68,9 @@ Ensure that the promotion stanza in your `ci-operator` configuration for your [d
 
 {{< highlight yaml >}}
 promotion:
-  namespace: ocp
-  name: 4.3
+  to:
+  - namespace: ocp
+    name: 4.3
 {{< / highlight >}}
 
 {{< alert title="Warning" color="warning" >}}

--- a/content/en/docs/architecture/ci-operator.md
+++ b/content/en/docs/architecture/ci-operator.md
@@ -314,12 +314,13 @@ allows release payloads to be created incorporating the latest tested version of
 
 {{< highlight yaml >}}
 promotion:
-  additional_images:
-    repo-scripts: "src"    # promotes "src" as "repo-scripts"
-  excluded_images:
-  - "mytests" # does not promote the test image
-  namespace: "ocp"
-  name: "4.5"
+  to:
+  - additional_images:
+      repo-scripts: "src"    # promotes "src" as "repo-scripts"
+    excluded_images:
+    - "mytests" # does not promote the test image
+    namespace: "ocp"
+    name: "4.5"
 {{< / highlight >}}
 
 ### Publishing to an Integration Namespace
@@ -335,12 +336,13 @@ add the following `promotion` stanza to `ci-operator` configuration.
 
 {{< highlight yaml >}}
 promotion:
-  additional_images:
-    repo-scripts: "src"    # promotes "src" as "repo-scripts"
-  excluded_images:
-  - "mytests" # does not promote the test image
-  namespace: "ocp"
-  tag: "4.5"
+  to:
+  - additional_images:
+      repo-scripts: "src"    # promotes "src" as "repo-scripts"
+    excluded_images:
+    - "mytests" # does not promote the test image
+    namespace: "ocp"
+    tag: "4.5"
 {{< / highlight >}}
 
 ### Publishing Images Tagged By Commit
@@ -358,13 +360,14 @@ that tracks the `latest` or most recent release, add `tag_by_commit: true` to th
 
 {{< highlight yaml >}}
 promotion:
-  additional_images:
-    repo-scripts: "src"    # promotes "src" as "repo-scripts"
-  excluded_images:
-  - "mytests" # does not promote the test image
-  namespace: "ocp"
-  tag: "4.5"
-  tag_by_commit: true # publish tags based on the git commit being built
+  to:
+  - additional_images:
+      repo-scripts: "src"    # promotes "src" as "repo-scripts"
+    excluded_images:
+    - "mytests" # does not promote the test image
+    namespace: "ocp"
+    tag: "4.5"
+    tag_by_commit: true # publish tags based on the git commit being built
 {{< / highlight >}}
 
 ## Describing OpenShift Releases Involved in Tests {#describing-inclusion-in-an-openshift-release}
@@ -739,8 +742,8 @@ installer will use pipeline:installer if that tag is present, falling back to st
 configuration fields use this defaulting mechanism:
 
 * `images[*].from`: configuring the base `FROM` which an image builds
-* `promotion.additional_images`: configuring which `images` are published
-* `promotion.excluded_images`: configuring which `images` are not published
+* `promotion.to[*].additional_images`: configuring which `images` are published
+* `promotion.to[*].excluded_images`: configuring which `images` are not published
 * `tests[*].container.from`: configuring the container image in which a single-stage test runs
 * `tests[*].steps.{pre,test,post}[*].from`: configuring the container image which some part of a multi-stage test runs
 

--- a/content/en/docs/architecture/ci-operator.md
+++ b/content/en/docs/architecture/ci-operator.md
@@ -370,6 +370,18 @@ promotion:
     tag_by_commit: true # publish tags based on the git commit being built
 {{< / highlight >}}
 
+### Publishing Images to multiple Namespaces
+Promotion is not limited to a single target anymore, several namespaces could be
+specified:
+{{< highlight yaml >}}
+promotion:
+  to:
+  - namespace: "ocp"
+    tag: "4.15"
+  - namespace: "origin"
+    tag: "4.15"
+{{< / highlight >}}
+
 ## Describing OpenShift Releases Involved in Tests {#describing-inclusion-in-an-openshift-release}
 
 `ci-operator` gives first-class support to repositories which need to run end-to-end tests in the context of an OpenShift

--- a/content/en/docs/getting-started/examples.md
+++ b/content/en/docs/getting-started/examples.md
@@ -60,11 +60,12 @@ In the following `ci-operator` configuration, the following `images` are promote
 {{< highlight yaml >}}
 test_binary_build_commands: go test -race -c -o e2e-tests # will create the test-bin tag
 promotion:
-  additional_images:
-    repo-scripts: src    # promotes "src" as "repo-scripts"
-    repo-tests: test-bin # promotes "test-bin" as "repo-tests"
-  namespace: ocp
-  name: 4.4
+  to:
+  - additional_images:
+      repo-scripts: src    # promotes "src" as "repo-scripts"
+      repo-tests: test-bin # promotes "test-bin" as "repo-tests"
+    namespace: ocp
+    name: 4.4
 images:
 - from: ubi8
   to: component # promotes "component" by default

--- a/content/en/docs/how-tos/use-registries-in-build-farm.md
+++ b/content/en/docs/how-tos/use-registries-in-build-farm.md
@@ -236,8 +236,9 @@ images:
   from: base
   to: my-component
 promotion:
-  name: "4.7"
-  namespace: ocp
+  to:
+  - name: "4.7"
+    namespace: ocp
 ```
 
 The `my-component` image can be pulled from the authoritative registry with:
@@ -257,8 +258,9 @@ images:
   from: base
   to: my-component
 promotion:
-  namespace: my-organization
-  tag: latest
+  to:
+  - namespace: my-organization
+    tag: latest
 ```
 
 The `my-component` image can be pulled from the authoritative registry with:


### PR DESCRIPTION
Adjust the documentation in accordance with https://github.com/openshift/ci-tools/pull/3858

Existing reference to:
```yaml
promotion:
  ...
```
have updated to:
```yaml
promotion:
  to:
    ...
```

Add new section that describes how to promote to multiple target.

/cc @openshift/test-platform