### PR TITLE
Fix the netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,5 +2,5 @@
 command = "make generate"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.111.3"
-NODE_VERSION = "14.18.0"
+HUGO_VERSION = "0.119.0"
+NODE_VERSION = "20.11.1"


### PR DESCRIPTION
/cc nobody

Let us see if it fix the build.

I can build it locally with

```console
$ hugo version
hugo v0.119.0-b84644c008e0dc2c4b67bd69cccf87a41a03937e+extended darwin/arm64 BuildDate=2023-09-24T15:20:17Z VendorInfo=brew
$ node -v
v20.11.1
```