### PR TITLE
Update mirroring-to-quay

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -102,13 +102,13 @@ function format ( d ) {
                 $('#hypershift_supported_versions').text(item['error']);
                 return;
               }
-              if (item['cluster'] === 'hive') {
+              if (item['cluster'] === 'hosted-mgmt') {
                 $('#hypershift_supported_versions').text(item["hypershiftSupportedVersions"]);
               }
             });
           },
           error: function(xhr) {
-            $("#hypershift_supported_versions").text('failed to load the hive cluster info: status ' + xhr.status);
+            $("#hypershift_supported_versions").text('failed to load the hosted-mgmt cluster info: status ' + xhr.status);
           },
         });
       }
@@ -126,7 +126,7 @@ function format ( d ) {
               var description=item['product'] + ' ' + item['version'] + ' cluster on ' + item['cloud'];
               if (item['cluster'] === 'app.ci') {
                 description=description+' containing most Prow services.';
-              } else if (item['cluster'] === 'hive') {
+              } else if (item['cluster'] === 'hosted-mgmt') {
                 description=description+' containing containing a Hive control plane.';
               } else if (!item['cluster'].startsWith('build')) {
                 description=description+' used for ' + item['cluster'].replace(/\d+/g, '').toUpperCase() + ' tests, not managed by DPTP.';
@@ -174,7 +174,7 @@ function format ( d ) {
                   var data="contains up-to-date image copies from the authoritative registry for jobs that run on this build farm only"
                   if (row['cluster'] === 'app.ci') {
                     data='the <a href="/docs/how-tos/use-registries-in-build-farm/#the-ci-image-repository-in-quayio-qci">deprecated</a> authoritative, central CI registry';
-                  } else if (row['cluster'] === 'hive') {
+                  } else if (row['cluster'] === 'hosted-mgmt') {
                     data='';
                   } else if (row['cluster'] === 'arm01' || row['cluster'] === 'vsphere') {
                     data=data+'; only open to ' + row['cluster'].replace(/\d+/g, '').toUpperCase() + ' admins';


### PR DESCRIPTION
https://issues.redhat.com/browse/DPTP-3932

/cc @openshift/test-platform 
/assign @deepsm007 

/hold

Need to notify the owners of the existing jobs with the wildcard


---
Update before merging:
Eventually, we keep the accessibility of `registry.ci.openshift.org` for the CI images.
This made [DPTP-3932](https://issues.redhat.com/browse/DPTP-3932) obsolete.
Instead of removing `registry.ci.openshift.org` from the mapping files, we use [a new image ](https://github.com/openshift/release/blob/a0e123b710797a0f1be6d0c5217efd457e644b95/clusters/app.ci/supplemental-ci-images/image-mirror-imagestream.yaml#L18) to simplify the job definitions.


