### PR TITLE
Update links for prow repository

### DIFF
--- a/content/en/docs/architecture/private-repositories.md
+++ b/content/en/docs/architecture/private-repositories.md
@@ -49,7 +49,7 @@ content, and all necessary CI configuration of the fork in `openshift-priv`:
    [private-org-peribolos-sync](https://github.com/openshift/ci-tools/tree/master/cmd/private-org-peribolos-sync) tool to
    maintain the GitHub settings for the fork. These settings are asynchronously consumed by the
    [periodic-org-sync](https://prow.ci.openshift.org/?job=periodic-org-sync) job running the
-   [peribolos](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/peribolos) tool to create the fork on GitHub
+   [peribolos](https://github.com/kubernetes-sigs/prow/tree/main/prow/cmd/peribolos) tool to create the fork on GitHub
    and maintain its settings
 1. The
    [periodic-openshift-release-private-org-sync](https://deck-internal-ci.apps.ci.l2s4.p1.openshiftapps.com/?job=periodic-openshift-release-private-org-sync)

--- a/content/en/docs/how-tos/onboarding-a-new-component.md
+++ b/content/en/docs/how-tos/onboarding-a-new-component.md
@@ -34,7 +34,7 @@ Both of them are required for automations to work properly, if one is missing yo
 ## Prow Configuration
 
 [Prow](https://docs.prow.k8s.io/docs/overview/) is the k8s-native upstream CI system, source
-code hosted in the [kubernetes/test-infra](https://github.com/kubernetes/test-infra) repository. Prow interacts with
+code hosted in the [kubernetes-sigs/prow](https://github.com/kubernetes-sigs/prow) repository. Prow interacts with
 GitHub to provide the automation UX that developers use on their pull requests, as well as orchestrating test workloads
 for those pull requests.
 
@@ -81,7 +81,7 @@ Most individual plugins can be configured to change their behavior; only some pl
 at a repository level, many only expose global configuration options for all repositories that Prow monitors. If you
 think you need to configure an individual plugin, consult a CI administrator. While we work on a better solution,
 documentation for these options lives in the `type Configuration struct`
-[here.](https://github.com/kubernetes/test-infra/blob/master/prow/plugins/plugins.go)
+[here.](https://github.com/kubernetes-sigs/prow/blob/main/prow/plugins/plugins.go)
 
 #### Repositories Under Existing Organizations
 
@@ -164,7 +164,7 @@ be placed into both `ci-operator/config/$org/$repo` and `ci-operator/jobs/$org/$
 
 ### Enabling Automatic Merges
 
-Prow’s [`tide`](https://github.com/kubernetes/test-infra/tree/master/prow/tide) component
+Prow’s [`tide`](https://github.com/kubernetes-sigs/prow/tree/main/prow/tide) component
 periodically searches for pull requests that fit merge criteria (for instance, presence of a `lgtm`
 label and absence of the `do-not-merge/hold` label) and merges them. `Tide` furthermore requires not only that all required
 tests in the Prow configuration succeed and all posted statuses on the GitHub pull request are green but also that the

--- a/content/en/docs/internals/artifacts.md
+++ b/content/en/docs/internals/artifacts.md
@@ -7,7 +7,7 @@ description: >
 
 ## Components
 
-Artifact collection is based on components from the [`test-infra`][test_infra]
+Artifact collection is based on components from the [`prow`][prow]
 repository.  These coordinating components are collectively know as
 [`pod-utilities`][pod_utils] and  augment the `pod_spec` declared in a `ProwJob`
 to add functionality such as [timeouts][timeouts], output censoring, execution
@@ -161,8 +161,8 @@ this.  The artifacts can be listed with:
 $ gsutil ls gs://$bucket/$path_prefix/… # …/logs/, …/pr-logs/, etc., as above
 {{< / highlight >}}
 
-[entrypoint]: https://github.com/kubernetes/test-infra/tree/master/prow/cmd/entrypoint
-[pod_utils]: https://github.com/kubernetes/test-infra/tree/master/prow/pod-utils
-[sidecar]: https://github.com/kubernetes/test-infra/tree/master/prow/cmd/sidecar
-[test_infra]: https://github.com/kubernetes/test-infra.git
+[entrypoint]: https://github.com/kubernetes-sigs/prow/tree/main/prow/cmd/entrypoint
+[pod_utils]: https://github.com/kubernetes-sigs/prow/tree/main/prow/pod-utils 
+[sidecar]: https://github.com/kubernetes-sigs/prow/tree/main/prow/cmd/sidecar
+[prow]: https://github.com/kubernetes-sigs/prow.git
 [timeouts]: {{< ref "/docs/architecture/timeouts" >}}

--- a/content/en/docs/internals/configuration-updates.md
+++ b/content/en/docs/internals/configuration-updates.md
@@ -30,12 +30,12 @@ components and is divided in the following steps:
    `kubelet` updates the contents of the directory to match the new contents of
    the mount.
 4. The service somehow (e.g. using the [`test-infra` configuration agent
-   package](https://github.com/kubernetes/test-infra/blob/master/prow/config/agent.go))
+   package](https://github.com/kubernetes-sigs/prow/blob/main/prow/config/agent.go))
    watches the mount directory and responds to those changes.
 
 ### `updateconfig`
 
-This [plugin](https://github.com/kubernetes/test-infra/tree/master/prow/plugins/updateconfig)
+This [plugin](https://github.com/kubernetes-sigs/prow/tree/main/prow/plugins/updateconfig)
 is configured by files under the Prow configuration directory,
 [`core-services/prow/02_config`](https://github.com/openshift/release/tree/master/core-services/prow/02_config).
 The [`openshift/release/_pluginconfig.yaml`](https://github.com/openshift/release/blob/master/core-services/prow/02_config/openshift/release/_pluginconfig.yaml)
@@ -91,7 +91,7 @@ by which `ConfigMap`s in the cluster are reconciled with the PR changes is:
 
 A second process, the [`openshift-release-master-config-bootstrapper`](https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/openshift-release-master-config-bootstrapper)
 periodic Prow job, also performs this procedure every hour using the
-[`config-bootstrapper`](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/config-bootstrapper)
+[`config-bootstrapper`](https://github.com/kubernetes-sigs/prow/tree/main/prow/cmd/config-bootstrapper)
 program, which shares most of its code with the plugin.  The job is not
 triggered by a PR, so all configured files are loaded as if the repository had
 just been created (hence its name).  It is meant to continually ensure the

--- a/content/en/docs/internals/steps.md
+++ b/content/en/docs/internals/steps.md
@@ -138,7 +138,7 @@ static validation.
 `SourceStep` takes the image defined in `build_root` and clones the source code
 of the repository under test into it. The resulting image is tagged as `src` in
 the `pipeline` `ImageStream`. This cloning process uses the
-[`clonerefs`](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/clonerefs)
+[`clonerefs`](https://github.com/kubernetes-sigs/prow/tree/main/prow/cmd/clonerefs)
 tool from `kubernetes/test-infra`.
 
 #### `PipelineImageCacheStep`

--- a/content/en/docs/internals/timeouts.md
+++ b/content/en/docs/internals/timeouts.md
@@ -6,7 +6,7 @@ description: >
 ---
 
 This section describes in detail how the CI infrastructure, both
-[upstream][test_infra] and [downstream][ci_tools], handles interruptions.  It is
+[upstream][prow] and [downstream][ci_tools], handles interruptions.  It is
 meant primarily for DPTP, but can also be useful when the [user
 documentation][user_documentation] fails to fully explain the behavior
 manifested in a job.
@@ -178,8 +178,8 @@ effect on the protocol for handling interruptions.
 
 [artifacts]: {{< ref "artifacts" >}}
 [ci_tools]: https://github.com/openshift/ci-tools.git
-[entrypoint]: https://github.com/kubernetes/test-infra/tree/master/prow/cmd/entrypoint
+[entrypoint]: https://github.com/kubernetes-sigs/prow/tree/main/prow/cmd/entrypoint
 [entrypoint_wrapper]: https://github.com/openshift/ci-tools/tree/master/cmd/entrypoint-wrapper
-[sidecar]: https://github.com/kubernetes/test-infra/tree/master/prow/cmd/sidecar
-[test_infra]: https://github.com/kubernetes/test-infra.git
+[sidecar]: https://github.com/kubernetes-sigs/prow/tree/main/prow/cmd/sidecar
+[prow]: https://github.com/kubernetes-sigs/prow.git
 [user_documentation]: {{< ref "/docs/architecture/timeouts" >}}


### PR DESCRIPTION
This updates url references for prow repository. https://github.com/kubernetes-sigs/prow

Fixing failures observed in https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_ci-docs/445/pull-ci-openshift-ci-docs-master-links/1780324439380987904 

/cc @openshift/test-platform 

