### PR TITLE
`helpdesk-faq`: `Subject` links also need to be formatted

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -194,7 +194,12 @@
                     "defaultContent": ''
                 },
                 {"data": "question.topic"},
-                {"data": "question.subject"},
+                {
+                    "data": "question.subject",
+                    "render": function (data, type, row, meta) {
+                        return formatLinks(data)
+                    }
+                },
                 {
                     "data": "question.body",
                     "render": function (data, type, row, meta) {


### PR DESCRIPTION
We recently had an FAQ item added with a link in the `subject`. We can display it nicely as well. There will never be links in the `topic` so that is left unchanged.