### PR TITLE
content/en/docs/architecture/jira: Comma -> space, when /cherrypick'ing multiple branches

### DIFF
--- a/content/en/docs/architecture/jira.md
+++ b/content/en/docs/architecture/jira.md
@@ -36,9 +36,9 @@ In order to backport a bugfix to more then one past release, it must be done ser
 is important because a bugfix must always been made in newer releases first, otherwise openshift cluster upgrades can
 lead to running into already fixed bugs which should never happen.
 
-When backporting to more than one release, users may specify all releases they which to backport to separated by commas
+When backporting to more than one release, users may specify all releases they which to backport to separated by spaces
 in their comment. For instance, if a bugfix needs to be backported to `release-4.15`, `release-4.14`, and `release-4.13`,
-the comment `/cherrypick release-4.15,release-4.14,release-4.13` can be made. When this is done, the automation will create
+the comment `/cherrypick release-4.15 release-4.14 release-4.13` can be made. When this is done, the automation will create
 a cherrypick for the first listed branch and include the remaining branches in the description. Once the new cherrypick is merged,
 the next branch will be handled the same and so on, without need for further cherrypcik comments to be manually made.
 


### PR DESCRIPTION
b4c09f89b3 (#457) landed docs for comma delimiters, but[ the Prow implementation says][1]:

> If multiple branches are specified, separated by a space...

and [uses `strings.Fields`][2], [which splits on whitespace][3].

[1]: https://github.com/kubernetes-sigs/prow/pull/136/files#diff-af91169cc704bac88f2d69a646fb521532a06add42cf44f1d9a5e7c4007e3f78R76
[2]: https://github.com/kubernetes-sigs/prow/pull/136/files#diff-af91169cc704bac88f2d69a646fb521532a06add42cf44f1d9a5e7c4007e3f78R192
[3]: https://pkg.go.dev/strings#Fields