### PR TITLE
remove unnessacary title in the multi arch documentation

### DIFF
--- a/content/en/docs/how-tos/multi-architecture.md
+++ b/content/en/docs/how-tos/multi-architecture.md
@@ -3,10 +3,6 @@ title: "Multi Architecture"
 description: "Configure ci-operator to build container images and run tests across multiple CPU architectures"
 ---
 
-# Multi Architecture
-
-Configure ci-operator to build container images and run tests across multiple CPU architectures.
-
 ## Building Multi-Architecture Images
 
 To build an image for the default `amd64` architecutre, no extra configuration is needed.


### PR DESCRIPTION
/cc @openshift/test-platform 

Title is not needed since the documentation page is adding the Description from the metadata.

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>
