### PR TITLE
NO-JIRA: include google html file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ RUN set -x && make generate
 FROM nginxinc/nginx-unprivileged:1.18-alpine
 
 COPY --from=builder /src/public/ /usr/share/nginx/html/
+COPY --from=builder /src/static/googlea8e04f239c597b8a.html /usr/share/nginx/html/
 COPY nginx/relative_redirect.sh /docker-entrypoint.d/

--- a/static/googlea8e04f239c597b8a.html
+++ b/static/googlea8e04f239c597b8a.html
@@ -1,0 +1,1 @@
+google-site-verification: googlea8e04f239c597b8a.html


### PR DESCRIPTION
This is needed so this content can be used as a data source for a slack chat bot.