### PR TITLE
NO-JIRA: set HUGO_ENV to production during build process in order to have site indexed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM klakegg/hugo:0.111.3-ext-ubuntu as builder
 
 COPY . /src/
 
-RUN set -x && make generate
+RUN set -x && HUGO_ENV=production make generate
 
 FROM nginxinc/nginx-unprivileged:1.18-alpine
 


### PR DESCRIPTION
This only controls google analytics and indexing. We need the indexing to happen in order to utilize content within the `ship-help` ai assistant.