### PR TITLE
content/en/how-tos/onboarding-a-new-component: ART instructions from art-docs

### DIFF
--- a/content/en/how-tos/onboarding-a-new-component.md
+++ b/content/en/how-tos/onboarding-a-new-component.md
@@ -271,8 +271,7 @@ file), or before you set the image label `io.openshift.release.operator` to get 
 
     CVO manifests may also use [the `0.0.1-snapshot` placeholder][cluster-version-manifest-version-placeholder] to have the OCP release version injected at release-assembly time.
 1. Ensure you have successfully published your image to the CI integration stream
-1. Follow the [ART instructions](https://source.redhat.com/groups/public/atomicopenshift/atomicopenshift_wiki/guidelines_for_requesting_new_content_managed_by_ocp_art) to have them build your image
-    * On the [dist-git part of the process](https://source.redhat.com/groups/public/atomicopenshift/atomicopenshift_wiki/requesting_a_new_image_or_rpm_to_be_managed_by_art#jive_content_id_Naming) it is critical that you ensure your component/image names match as described in the bulleted criteria
+1. Follow the [ART instructions](https://art-docs.engineering.redhat.com/sop/image_add/) to have them build your image
 1. Ensure a single successful build is run (sync with ART to confirm).  You can also check for your new image name in both ART and CI ImageStreams by checking [CI registries](/how-tos/use-registries-in-build-farm/#how-do-i-gain-access-to-qci):
 
     ```console


### PR DESCRIPTION
On 2024-02-12, [the old Source page][1] was updated to say:

> Please visit our [documentation for the updated process][2].

Catch up with that change.

I'm also dropping the component/image name requirement, because on 2024-03-21, [that Source page][3] was updated to say:

> This page is outdated, please see https://art-docs.engineering.redhat.com/sop/image_add/ instead.

And we don't need a sub-list-entry to point at the same art-docs page the parent list entry is already pointing to.

[1]: https://source.redhat.com/departments/products_and_global_engineering/openshift_development/openshift_wiki/guidelines_for_requesting_new_content_managed_by_ocp_art
[2]: https://art-docs.engineering.redhat.com/sop/image_add/
[3]: https://source.redhat.com/departments/products_and_global_engineering/openshift_development/openshift_wiki/requesting_a_new_image_or_rpm_to_be_managed_by_art