### PR TITLE
Renamed hive to hostedmgmt for better context

### DIFF
--- a/assets/js/registries.js
+++ b/assets/js/registries.js
@@ -9,7 +9,7 @@ $(document).ready(function () {
         "info": false,
         "searching": false,
         "ajax": {
-            "url": window.HUGO_PARAMS.api_v1_url + "/api/v1/clusters?skipHive=true",
+            "url": window.HUGO_PARAMS.api_v1_url + "/api/v1/clusters?skipHostedMgmt=true",
             "dataType": "jsonp",
         },
         "columns": [


### PR DESCRIPTION
This is just for context purposes, this query string variable will be used on `cluster-display` and there is easier to understand that we are skipping `hosted-mgmt` clusters 1 and 2.

Related to https://github.com/openshift/ci-tools/pull/5342